### PR TITLE
feat(config, env, Test): initialise config and env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ with
 [BEM Naming](https://css-tricks.com/bem-101/)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
+
+
+<h2 style="font-family='Helvetica'; font-size=15px; font-weight=bold; color=grey;">⭐️ Config</h2>
+
+There are two places where application configuration is defined:
+
+- utils/env.js contains the env variables like the algolia app ID, index names etc.
+
+- config/config.js contains layout variables like the refinements, sorts etc.
+    - the config is exported via an object which is controlled by a state atom (see state section for more details)

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/algolia/demo-engineer-react-boilerplateV2#readme",
   "dependencies": {
+    "@algolia/react-instantsearch-widget-color-refinement-list": "^1.4.5",
     "@vitejs/plugin-react": "^1.1.4",
     "css-loader": "^6.5.1",
     "react": "^17.0.2",

--- a/src/Pages/Test.jsx
+++ b/src/Pages/Test.jsx
@@ -5,7 +5,15 @@ import { Link } from "react-router-dom";
 
 import { atom, useRecoilState, selector, useRecoilValue } from "recoil";
 
+// application state from config file
+import { configAtom } from "../config/config";
+
+
 const Test = () => {
+  // access config state and log for testing
+  const [config] = useRecoilState(configAtom);
+  console.log(config)
+
   return (
     <div>
       <TextInput />

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,0 +1,136 @@
+import { atom } from 'recoil'
+
+import { indexName } from '../utils/env'
+
+import {
+  Layout,
+  Shape,
+} from '@algolia/react-instantsearch-widget-color-refinement-list'
+
+const refinements = [
+  {
+    type: 'hierarchical',
+    header: 'Categories',
+    label: 'Category',
+    isExpanded: true,
+    options: {
+      attributes: [
+        'hierarchical_categories.lvl0',
+        'hierarchical_categories.lvl1',
+        'hierarchical_categories.lvl2',
+      ],
+    },
+  },
+  {
+    type: 'price',
+    header: 'Price',
+    label: 'Price',
+    options: {
+      attribute: 'price.value',
+    },
+  },
+  {
+    type: 'list',
+    header: 'Brand',
+    label: 'Brand',
+    options: {
+      attribute: 'brand',
+      searchable: true,
+    },
+  },
+  {
+    type: 'color',
+    layout: Layout.Grid,
+    shape: Shape.Circle,
+    header: 'Color',
+    label: 'Color',
+    options: {
+      attribute: 'color.filter_group',
+    },
+  },
+  {
+    type: 'list',
+    header: 'Gender',
+    label: 'Gender',
+    options: {
+      attribute: 'gender',
+    },
+  },
+  {
+    type: 'size',
+    header: 'Sizes',
+    label: 'Size',
+    options: {
+      attribute: 'available_sizes',
+      limit: 8,
+    },
+  },
+  {
+    type: 'rating',
+    header: 'Rating',
+    label: 'Rating',
+    options: {
+      attribute: 'reviews.rating',
+    },
+  },
+  {
+    type: 'list',
+    header: 'On Sale',
+    label: 'On Sale',
+    options: {
+      attribute: 'price.on_sales',
+    },
+  },
+]
+
+const sorts = [
+  { value: indexName, label: 'Most popular', isDefault: true },
+  {
+    value: `${indexName}_asc_price`,
+    label: 'Price Low to High (Traditional Sort',
+  },
+  {
+    value: `${indexName}_asc_price_virtual_replica`,
+    label: 'Price Low to High (Relevant Sort)',
+  },
+  { value: `${indexName}_desc_price`, label: 'Price High to Low' },
+]
+
+const breadcrumbAttributes = [
+  'hierarchical_categories.lvl0',
+  'hierarchical_categories.lvl1',
+  'hierarchical_categories.lvl2',
+]
+
+const searchParameters = {
+  hitsPerPage: 10,
+  maxValuesPerFacet: 50,
+  attributesToSnippet: ['description:30'],
+  snippetEllipsisText: '…',
+  analytics: true,
+  clickAnalytics: true,
+}
+
+const autocomplete = {
+  placeholders: ['products', 'articles', 'faq'],
+  debouncing: 800, // in ms
+  detachedMediaQuery: '(max-width: 1439px)',
+}
+
+const url = {
+  debouncing: 1500, // in ms
+}
+
+const config = {
+  refinements,
+  sorts,
+  breadcrumbAttributes,
+  searchParameters,
+  autocomplete,
+  url,
+}
+
+export const configAtom = atom({
+  key: 'configAtom', // unique ID (with respect to other atoms/selectors)
+  default: config, // default value (aka initial value)
+})

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,0 +1,9 @@
+export const isDev = process.env.NODE_ENV === 'development'
+export const isProd = process.env.NODE_ENV === 'production'
+export const isTest = process.env.NODE_ENV === 'test'
+
+// InstantSearch
+export const appId = 'XXXX'
+export const searchApiKey = 'XXXX'
+export const indexName = 'XXXX'
+export const querySuggestionsIndexName = 'XXXX'


### PR DESCRIPTION
## Objective
Initialise two files for isolating and exposing configuration.

## Type
- [X] New Feature

## Work Done
1. Create an env file, and a config file
2. Export the key variables from each file.
3. Access some variables in Test file to ensure completeness

## Notes
There are two files instead of one because there should be a seperation of concerns between environment variables and other variables. Config controls specific variables like refinements, sorts etc. and imports and uses things like the main index name from the second file called env, while contains variables like the App ID and Index names.

The values inside config and env don't matter at this stage, they will be redefined on implementation of widgets, the important work is the system of isolating, splitting and exposing key variables so that a demo can easily be reconfigured and understood at any time.


## Screenshots / Output
<img width="574" alt="Screenshot 2022-02-01 at 09 52 29" src="https://user-images.githubusercontent.com/10894967/152002306-73ac8131-de44-4c93-8945-90f4691e9321.png">
<img width="1499" alt="Screenshot 2022-02-01 at 09 53 35" src="https://user-images.githubusercontent.com/10894967/152002503-7e1fabda-872a-45b8-8a90-b44d89ee2ca8.png">


## Tested
App run locally with console log active to check imports and exports all accessible.
