### PR TITLE
Feature/config hits

### DIFF
--- a/src/components/federatedSearch/components/Products.jsx
+++ b/src/components/federatedSearch/components/Products.jsx
@@ -17,6 +17,8 @@ import { useNavigate } from 'react-router-dom';
 const Hits = ({ hits }) => {
   const navigate = useNavigate();
   const hitState = useSetRecoilState(hitAtom);
+
+  // Get hit attribute from config file
   const { price, objectID, image, productName, brand } =
     useRecoilValue(hitsConfig);
   return (

--- a/src/components/hits/Hits.jsx
+++ b/src/components/hits/Hits.jsx
@@ -17,6 +17,8 @@ import { useNavigate } from 'react-router-dom';
 const Hit = ({ hit }) => {
   const navigate = useNavigate();
   const hitState = useSetRecoilState(hitAtom);
+
+  // Get hit attribute from config file
   const { price, objectID, image, category, productName } =
     useRecoilValue(hitsConfig);
 

--- a/src/config/Hits.js
+++ b/src/config/Hits.js
@@ -1,5 +1,6 @@
 import { atom } from 'recoil';
 
+// Change string attribute here with the attribute of your index
 export const hitsConfig = atom({
   key: 'hitsConfig', // unique ID (with respect to other atoms/selectors)
   default: {


### PR DESCRIPTION
## Objective

Describe the problem and what is to be achieved with this pull request...
- What is it?
👉 Hit attribute are now directly handle by a config file. config > hits.js
- Why is it needed?
👉 To make our life easier when indexes doesn't have same aattribute as the previous one
- How is it implemented?
👉 Through a config file in config > hits.js
- How is it customised?
👉 it's fully customisable 

## Type

- [x] Code Refactoring


## Work Done

👉  Creating a config file and changed all the attribute from SRP & Federated Search

## Screenshots / Output

<img width="624" alt="Screenshot 2022-02-16 at 14 38 29" src="https://user-images.githubusercontent.com/47173348/154276182-3a9dc668-dfb7-4931-b705-c894f6a0ae7f.png">

## Tested
✅

## Documented

- [x] Have you documented in changed file using comments
- [ ] Have you added instructions to the README if needed?
