### PR TITLE
fix: link for all products in federated

### DIFF
--- a/src/components/federatedSearch/components/Products.jsx
+++ b/src/components/federatedSearch/components/Products.jsx
@@ -66,7 +66,7 @@ const Hits = ({ hits }) => {
       </ul>
       <div className="products__btn" onClick={() => {}}>
         <ChevronRight />
-        <p>SHOW ALL PRODUCTS</p>
+        <p onClick={() => navigate('/search')}>SHOW ALL PRODUCTS</p>
       </div>
     </div>
   );

--- a/src/scss/federatedSearch/federatedSearch.scss
+++ b/src/scss/federatedSearch/federatedSearch.scss
@@ -136,6 +136,7 @@
         align-items: center;
         gap: 0.5rem;
         margin-top: 2rem;
+        cursor: pointer;
     }
 }
 


### PR DESCRIPTION
## Objective
What: Adds link to "Show all products" in federated search
Why: Needs a link, didn't have one
How: useNavigate hook
Usage: Click on link, route to SRP

## Type

- [X] Bug Fix

## Work Done
NA

## Screenshots / Output
NA

## Tested
NA

## Documented
- [ ] Have you documented in changed file using comments
- [ ] Have you added instructions to the README if needed?
