### PR TITLE
fix: add functionality to retain federated modal when navigation drop…

### DIFF
--- a/src/components/federatedSearch/FederatedSearch.jsx
+++ b/src/components/federatedSearch/FederatedSearch.jsx
@@ -31,9 +31,13 @@ import { queryAtom, searchBoxAtom } from '@/config/searchboxConfig';
 // Import Persona State from recoil
 import { personaSelectedAtom } from '@/config/personaConfig';
 
+// Import refs for modal closing functionality
+import { federatedRef } from '@/config/federatedConfig';
+import { selectorNavigationRef } from '@/config/headerConfig';
+
 // hook import
 // Check if user is clecking outside an element
-import useOutsideClickConditional from '@/hooks/useOutsideClickConditional';
+import useOutsideClickTwoConditions from '@/hooks/useOutsideClickTwoConditions';
 // Check screensize for responsiveness
 import useScreenSize from '@/hooks/useScreenSize';
 
@@ -52,12 +56,16 @@ const FederatedSearch = () => {
   const searchboxRef = useRecoilValue(searchBoxAtom);
   const query = useRecoilValue(queryAtom);
 
+  //Get reference for dropdowns in Navigation
+  const selector = useRecoilValue(selectorNavigationRef);
+
   // Get Indexes Name
   const { suggestionsIndex, articlesIndex } = useRecoilValue(indexNames);
 
   const containerFederated = useRef('');
+
   // Custom hook
-  useOutsideClickConditional(containerFederated, searchboxRef, () =>
+  useOutsideClickTwoConditions(containerFederated, searchboxRef, selector, () =>
     setIsFederated(false)
   );
 

--- a/src/config/federatedConfig.js
+++ b/src/config/federatedConfig.js
@@ -20,3 +20,8 @@ export const shouldHaveOpenFederatedSearch = atom({
   key: 'shouldHaveOpenFederatedSearch', // unique ID (with respect to other atoms/selectors)
   default: false, // default value (aka initial value)
 });
+
+export const federatedRef = atom({
+  key: 'federatedRef', // unique ID (with respect to other atoms/selectors)
+  default: "", // default value (aka initial value)
+})

--- a/src/config/headerConfig.js
+++ b/src/config/headerConfig.js
@@ -34,3 +34,8 @@ export const linksHeader = atom({
     },
   ],
 });
+
+export const selectorNavigationRef = atom({
+  key: 'selectorNavigationRef', // unique ID (with respect to other atoms/selectors)
+  default: '',
+})

--- a/src/hooks/useOutsideClickTwoConditions.jsx
+++ b/src/hooks/useOutsideClickTwoConditions.jsx
@@ -1,0 +1,33 @@
+// This is for closing federated search window when clicking outside of the modal
+
+import { useEffect } from 'react';
+
+const useOutsideClickTwoConditionals = (
+  ref,
+  optionalParameter1,
+  optionalParameter2,
+  callback
+) => {
+  optionalParameter1 ||= null;
+  const handleClick = (e) => {
+    if (
+      ref &&
+      !ref.contains(e.target) &&
+      !optionalParameter1.contains(e.target) &&
+      !optionalParameter2.contains(e.target) &&
+      !e.target.classList.contains('react-select__option')
+    ) {
+      callback();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('click', handleClick);
+
+    return () => {
+      document.removeEventListener('click', handleClick);
+    };
+  });
+};
+
+export default useOutsideClickTwoConditionals;

--- a/src/scss/federatedSearch/federatedSearch.scss
+++ b/src/scss/federatedSearch/federatedSearch.scss
@@ -5,7 +5,7 @@
     padding: 2rem;
     position: absolute;
     background-color: $background-color;
-    z-index: 999;
+    z-index: 40;
 
    
     &__wrapper{

--- a/src/scss/header/header.scss
+++ b/src/scss/header/header.scss
@@ -80,6 +80,7 @@
         display: flex;
         justify-content: center;
         li {
+          z-index: 50;
           margin-left: $two-rem-spaces;
           cursor: pointer;
           p {


### PR DESCRIPTION
…down is clicked

## Objective

Describe the problem and what is to be achieved with this pull request...
- What is it?
- Why is it needed?
- How is it implemented?
- How is it customised?

What: The dropdown selectors in the Header shouldn't close the Federated Search, and should appear on top as well.
Why: Users can use the dropdowns while on Federated
How: Copy some code from RL, edit the z-indexes
Usage: Add custom Hooks

## Type

- [ ] Bug Fix
- [X] New Feature
- [X] Performance Tweaks
- [X] Style Tweaks
- [X] Code Refactoring
- [ ] Documentation
- [ ] Tests

## Work Done

Outline your technical solution and the changes made to the code base to achieve the goals stated above...

## Screenshots / Output

Add screenshots or a representation of the desired effect or output achiev
<img width="1689" alt="Screenshot 2022-04-27 at 09 51 14" src="https://user-images.githubusercontent.com/72299424/165480423-ff75deed-7413-490e-8b83-356c3b490782.png">
ed...

## Tested

Locally


## Documented

- [X] Have you documented in changed file using comments
- [ ] Have you added instructions to the README if needed?
