### PR TITLE
fix: use attributes which exist in the default dataset

### DIFF
--- a/src/config/segmentConfig.js
+++ b/src/config/segmentConfig.js
@@ -12,12 +12,12 @@ import { atom } from 'recoil';
 export const segmentConfig = [
   { value: '', label: 'No Segment' },
   {
-    value: ['season:2022 SPRING', 'hierarchicalCategory.0:Women'],
-    label: 'Female New Season Segment',
+    value: ['hierarchicalCategories.lvl0:Womens'],
+    label: 'Female Segment',
   },
   {
-    value: ['brand:Purple Label', 'hierarchicalCategory.0:Men'],
-    label: 'Male Purple Label Segment',
+    value: ['hierarchicalCategories.lvl0:Mens'],
+    label: 'Male Segment',
   },
 ];
 


### PR DESCRIPTION
## Objective
What: Segments did not work as they did not relate to attributes present in the dataset
Why: NA
How: NA
Usage: NA

## Type
- [X] Bug Fix

## Tested
Ran locally

## Documented
- [ ] Have you documented in changed file using comments
- [ ] Have you added instructions to the README if needed?
