### PR TITLE
fix: carousels adapt to segments

### DIFF
--- a/src/components/carousels/HomeCarousel.jsx
+++ b/src/components/carousels/HomeCarousel.jsx
@@ -15,6 +15,7 @@ import { mainIndex } from '@/config/algoliaEnvConfig';
 import { hitsConfig, hitAtom } from '@/config/hitsConfig';
 import { hitsPerCarousel } from '@/config/carouselConfig';
 import { personaSelectedAtom } from '@/config/personaConfig';
+import { segmentSelectedAtom } from '@/config/segmentConfig';
 import {
   currencySymbolAtom,
   shouldIdisplayCurrency,
@@ -33,6 +34,8 @@ import get from 'lodash/get';
 const HomeCarousel = ({ context, title }) => {
   const index = useRecoilValue(mainIndex);
   const userToken = useRecoilValue(personaSelectedAtom);
+  const segmentOptionalFilters = useRecoilValue(segmentSelectedAtom);
+
   const { tablet, mobile } = useScreenSize();
   return (
     <div className={`${mobile ? 'home-carousel-mobile' : 'home-carousel'}`}>
@@ -40,6 +43,7 @@ const HomeCarousel = ({ context, title }) => {
         <Configure
           hitsPerPage={hitsPerCarousel}
           ruleContexts={context}
+          optionalFilters={segmentOptionalFilters}
           userToken={userToken}
         />
         <CustomHitsCarousel title={title} />

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -77,14 +77,14 @@ const HomePage = () => {
         <CustomHomeBanners />
       </Suspense>
 
-      {homepage_1 ? <img src={homepage_1} alt="" /> : null}
-
       {isCarousel &&
         carouselConfig.map((carousel, i) => (
           <Suspense key={i} fallback={<Loader />}>
             <HomeCarousel context={carousel.context} title={carousel.title} />
           </Suspense>
         ))}
+        
+      {homepage_1 ? <img src={homepage_1} alt="" /> : null}
 
       {homepage_2 && <img src={homepage_2} alt="" />}
     </motion.div>


### PR DESCRIPTION
## Objective
What: carousels now react to segments
Why: everything powered by algolia should be adaptable
How: optional filters in request to fetch carousel products
Usage: as normal

## Type
- [X] Bug Fix


## Tested
Ran locally

## Documented
- [ ] Have you documented in changed file using comments
- [ ] Have you added instructions to the README if needed?
