### PR TITLE
fix: update persona select when demo guide used, fix alert content

### DIFF
--- a/src/components/demoGuide/components/SearchPersona.jsx
+++ b/src/components/demoGuide/components/SearchPersona.jsx
@@ -52,8 +52,9 @@ const SearchPersona = () => {
         placeholder="Persona"
         onChange={(e) => {
           if (e.value !== 'anon') {
+            console.log(e)
             setPersonaSelect(e.value);
-            triggerAlert(e.alertContent);
+            triggerAlert(e.description);
           }
         }}
       />

--- a/src/components/header/personnaSelect/SelectPersona.jsx
+++ b/src/components/header/personnaSelect/SelectPersona.jsx
@@ -8,7 +8,7 @@ import { memo } from 'react';
 import Select from 'react-select';
 
 // Import Recoil for state management
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 
 // Import configuration
 import {
@@ -18,15 +18,18 @@ import {
 } from '@/config/personaConfig';
 
 const SelectPersona = () => {
-  const setPersonaSelect = useSetRecoilState(personaSelectedAtom);
+  const [personaSelected, setPersonaSelect] = useRecoilState(personaSelectedAtom);
 
   // When the persona is selected, set it to be the selected persona in the Recoil state
   return (
     <Select
-      defaultValue={personaConfig}
+      // defaultValue={personaSelected}
+      value={personaConfig.filter(function(option) {
+        return option.value === personaSelected;
+      })}
       options={personaConfig}
       styles={styles}
-      placeholder="Persona"
+      placeholder="No Persona"
       onChange={(e) => {
         setPersonaSelect(e.value);
       }}

--- a/src/config/personaConfig.js
+++ b/src/config/personaConfig.js
@@ -11,7 +11,7 @@ import { atom } from 'recoil';
 // Just make sure you have events and profiles for your values
 // ------------------------------------------
 export const personaConfig = [
-  { value: '', label: 'Neutral', description: 'Anonymous user' },
+  { value: 'anon', label: 'No Persona', description: 'Anonymous user' },
   {
     value: 'stephen_james',
     label: 'Stephen',
@@ -100,7 +100,7 @@ export const styles = {
 // Please ignore this atom
 export const personaSelectedAtom = atom({
   key: 'personaSelected', // unique ID (with respect to other atoms/selectors)
-  default: '', // default value (aka initial value)
+  default: personaConfig[0].value, // default value (aka initial value)
 });
 
 // Please ignore this atom


### PR DESCRIPTION
## Objective
What: Ensure persona select and demo guide are in sync
Why: clearer usage of the app
How: use the atom as standard
Usage: as normal

## Type
- [X] Bug Fix

## Tested
Ran locally


## Documented
- [ ] Have you documented in changed file using comments
- [ ] Have you added instructions to the README if needed?
