### PR TITLE
feat: make hitsConfig a regular object, refinements from hits

### DIFF
--- a/src/components/carousels/HomeCarousel.jsx
+++ b/src/components/carousels/HomeCarousel.jsx
@@ -66,7 +66,7 @@ const Carousel = ({ hits, title }) => {
   // Hits are imported by Recoil
   const hitState = useSetRecoilState(hitAtom);
   const displayCurrency = useRecoilValue(shouldDisplayCurrency);
-  const { price, objectID, image, productName } = useRecoilValue(hitsConfig);
+  const { price, objectID, image, productName } = hitsConfig;
 
   // Used by Framer Motion
   const carousel = useRef();

--- a/src/components/facets/CurrentRefinement.jsx
+++ b/src/components/facets/CurrentRefinement.jsx
@@ -40,7 +40,7 @@ const displayColor = (i) => {
 };
 
 const CurrentRefinements = ({ items, refine, createURL }) => {
-  const { colourHexa } = useRecoilValue(hitsConfig);
+  const { colourHexa } = hitsConfig;
   const currencySymbol = useRecoilValue(currencySymbolAtom);
   return (
     <ul className="refinement-container__refinements">

--- a/src/components/federatedSearch/components/Products.jsx
+++ b/src/components/federatedSearch/components/Products.jsx
@@ -35,8 +35,7 @@ const Hits = ({ hits }) => {
   const displayCurrency = useRecoilValue(shouldDisplayCurrency);
 
   // Get hit attribute from config file
-  const { price, objectID, image, productName, brand } =
-    useRecoilValue(hitsConfig);
+  const { price, objectID, image, productName, brand } = hitsConfig;
 
   return (
     <div className="products">

--- a/src/components/hits/Hits.jsx
+++ b/src/components/hits/Hits.jsx
@@ -43,8 +43,7 @@ const Hit = ({ hit }) => {
   const displayCurrency = useRecoilValue(shouldDisplayCurrency);
 
   // Get hit attribute from config file
-  const { price, objectID, image, imageAlt, category, productName } =
-    useRecoilValue(hitsConfig);
+  const { price, objectID, image, imageAlt, category, productName } = hitsConfig;
 
   return (
     <motion.li

--- a/src/components/recommend/RelatedProducts.jsx
+++ b/src/components/recommend/RelatedProducts.jsx
@@ -18,7 +18,7 @@ import { Heart } from '@/assets/svg/SvgIndex';
 
 const RelatedItem = ({ item }) => {
   // Get hit attribute from config file
-  const { price, image, category, productName } = useRecoilValue(hitsConfig);
+  const { price, image, category, productName } = hitsConfig;
   // Get currency symbol
   const currency = useRecoilValue(currencySymbolAtom);
   const displayCurrency = useRecoilValue(shouldDisplayCurrency);

--- a/src/config/hitsConfig.js
+++ b/src/config/hitsConfig.js
@@ -10,30 +10,27 @@ import { atom } from 'recoil';
 // Please change only the values in this const i.e. the strings on the right of the semi-colons
 // If you do not have an attribute in your data please do not remove it from here, contact #help-demos
 // ------------------------------------------
-export const hitsConfig = atom({
-  key: 'hitsConfig',
-  default: {
-    objectID: 'objectID',
-    productName: 'name',
-    brand: 'brand',
-    category: 'category',
-    reviewScore: 'reviewScore',
-    reviewCount: 'reviewCount',
-    categories: 'categories',
-    colour: 'colour',
-    genderFilter: 'genderFilter',
-    hierarchicalCategories: 'hierarchicalCategories',
-    sizeFilter: 'sizeFilter',
-    price: 'price',
-    image: 'img_optimised',
-    imageAlt: 'imageAlt',
-    hierarchicalCategoriesLvl0: 'hierarchicalCategories.lvl0',
-    hierarchicalCategoriesLvl1: 'hierarchicalCategories.lvl1',
-    hierarchicalCategoriesLvl2: 'hierarchicalCategories.lvl2',
-    hierarchicalCategoriesLvl3: 'hierarchicalCategories.lvl3',
-    colourHexa: 'colour_hexa_v6',
-  },
-});
+export const hitsConfig = {
+  objectID: 'objectID',
+  productName: 'name',
+  brand: 'brand',
+  category: 'category',
+  reviewScore: 'reviewScore',
+  reviewCount: 'reviewCount',
+  categories: 'categories',
+  colour: 'colour',
+  genderFilter: 'genderFilter',
+  hierarchicalCategories: 'hierarchicalCategories',
+  sizeFilter: 'sizeFilter',
+  price: 'price',
+  image: 'img_optimised',
+  imageAlt: 'imageAlt',
+  hierarchicalCategoriesLvl0: 'hierarchicalCategories.lvl0',
+  hierarchicalCategoriesLvl1: 'hierarchicalCategories.lvl1',
+  hierarchicalCategoriesLvl2: 'hierarchicalCategories.lvl2',
+  hierarchicalCategoriesLvl3: 'hierarchicalCategories.lvl3',
+  colourHexa: 'colour_hexa_v6',
+};
 
 // ------------------------------------------
 // This const defines what parts of a hit you want to show on the PDP or not

--- a/src/config/refinementsConfig.js
+++ b/src/config/refinementsConfig.js
@@ -2,6 +2,8 @@
 // Configuration for refinements/facets
 // ------------------------------------------
 
+import { hitsConfig } from './hitsConfig';
+
 // This const defines the refinements to be shown
 // There are five possible types: hierarchical, price, colour, size, list
 // Generally you should use type list if you are adding a new facet here
@@ -12,10 +14,10 @@ export const refinements = [
     label: 'Category',
     options: {
       attribute: [
-        'hierarchicalCategories.lvl0',
-        'hierarchicalCategories.lvl1',
-        'hierarchicalCategories.lvl2',
-        'hierarchicalCategories.lvl3',
+        hitsConfig.hierarchicalCategoriesLvl0,
+        hitsConfig.hierarchicalCategoriesLvl1,
+        hitsConfig.hierarchicalCategoriesLvl2,
+        hitsConfig.hierarchicalCategoriesLvl3,
       ],
       searchable: true,
     },
@@ -25,7 +27,7 @@ export const refinements = [
     header: 'Price',
     label: 'Price',
     options: {
-      attribute: 'unformated_price',
+      attribute: hitsConfig.price,
     },
   },
   {
@@ -33,7 +35,7 @@ export const refinements = [
     header: 'Brand',
     label: 'Brand',
     options: {
-      attribute: 'brand',
+      attribute: hitsConfig.brand,
       searchable: true,
     },
   },
@@ -42,7 +44,7 @@ export const refinements = [
     header: 'Colour',
     label: 'Colour',
     options: {
-      attribute: 'colour_hexa_v6',
+      attribute: hitsConfig.colourHexa,
     },
   },
   {
@@ -50,7 +52,7 @@ export const refinements = [
     header: 'Gender',
     label: 'Gender',
     options: {
-      attribute: 'genderFilter',
+      attribute: hitsConfig.genderFilter,
     },
   },
   {
@@ -58,7 +60,7 @@ export const refinements = [
     header: 'Sizes',
     label: 'Size',
     options: {
-      attribute: 'sizeFilter',
+      attribute: hitsConfig.sizeFilter,
       limit: 8,
     },
   },

--- a/src/pages/ProductDetails.jsx
+++ b/src/pages/ProductDetails.jsx
@@ -105,7 +105,7 @@ const ProductDetails = () => {
     sizeFilter,
     colour,
     colourHexa,
-  } = useRecoilValue(hitsConfig);
+  } = hitsConfig;
 
   const hexaCode = get(hit, colourHexa)?.split(';')[1];
 


### PR DESCRIPTION
## Objective
What: Feed refinement attributes from hitsConfig
Why: So SE's don't need to enter config in two places
How: Make hitsConfig regular object, reference it
Usage: Just use hitsConfig

## Type
- [X] Code Refactoring

## Tested
Ran locally

## Documented
- [ ] Have you documented in changed file using comments
- [ ] Have you added instructions to the README if needed?
