### PR TITLE
fix: setSrpIsLoaded props dont go back in child component

### DIFF
--- a/src/components/hits/CustomHits.jsx
+++ b/src/components/hits/CustomHits.jsx
@@ -5,13 +5,13 @@ import { connectHits } from 'react-instantsearch-dom';
 
 import { Hit } from './Hits';
 
-const CustomHits = ({ hits }) => {
+const CustomHits = ({ hits, setSrpIsLoaded }) => {
   return (
     <div className="ais-InfiniteHits">
       <ul className="ais-InfiniteHits-list">
         {hits.map((hit, i) => {
           // Wrap the hit info in an animation, and click functionality to view the product
-          return <Hit hit={hit} key={i} />;
+          return <Hit hit={hit} key={i} setSrpIsLoaded={setSrpIsLoaded} />;
         })}
       </ul>
     </div>

--- a/src/components/searchresultpage/srpLaptop/SrpLaptop.jsx
+++ b/src/components/searchresultpage/srpLaptop/SrpLaptop.jsx
@@ -206,7 +206,7 @@ const SrpLaptop = ({ setSrpIsLoaded, srpIsLoaded }) => {
             </Suspense>
           ) : (
             <Suspense fallback={''}>
-              <CustomHitsComponent />
+              <CustomHitsComponent setSrpIsLoaded={setSrpIsLoaded} />
             </Suspense>
           )}
           <Pagination />

--- a/src/components/searchresultpage/srpMobile/SrpMobile.jsx
+++ b/src/components/searchresultpage/srpMobile/SrpMobile.jsx
@@ -205,7 +205,7 @@ const SrpMobile = ({ setSrpIsLoaded, srpIsLoaded }) => {
           </Suspense>
         ) : (
           <Suspense fallback={<Loader />}>
-            <CustomHitsComponent />
+            <CustomHitsComponent setSrpIsLoaded={setSrpIsLoaded} />
           </Suspense>
         )}
         <Redirect />


### PR DESCRIPTION
## Objective
What: There was an issue on `setSrpIsLoaded` when contentInjection was not displayed. 
When we used customHits without contentInjection


## Type

- [x] Bug Fix



## Tested

✅

