### PR TITLE
fix: wrap all SRP in the NoResutsHandler

### DIFF
--- a/src/pages/SearchResultsPage.jsx
+++ b/src/pages/SearchResultsPage.jsx
@@ -84,15 +84,15 @@ const SearchResultPage = ({ setIsMounted }) => {
   return (
     <div ref={srpMounted} className="srp">
       {/* Create a skeleton while page is loading */}
-      <AnimatePresence>
-        {srpIsLoaded === false && <SkeletonLoader />}
-      </AnimatePresence>
-
-      {/* Display the banner if the bannerSrp config is set to: true */}
-      {shouldDisplayBanners && <Banner />}
-      {/* This wrapper will  decide to render the NoResults component if there are no results from the search */}
-
       <NoResultsHandler>
+        <AnimatePresence>
+          {srpIsLoaded === false && <SkeletonLoader />}
+        </AnimatePresence>
+
+        {/* Display the banner if the bannerSrp config is set to: true */}
+        {shouldDisplayBanners && <Banner />}
+        {/* This wrapper will  decide to render the NoResults component if there are no results from the search */}
+
         <Suspense fallback={''}>
           {(laptop || laptopXS) && (
             <SrpLaptop


### PR DESCRIPTION
## Objective
What: The noResults Behaviour was wrong
Why: Because the NoResultsHandler wasn't wrapping all the SRP with the skeleton


## Type

- [x] Bug Fix



## Tested

✅

