### PR TITLE
Feature: Trending Products Carousel

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,6 +9,7 @@ module.exports = {
   parser: '@babel/eslint-parser',
   rules: {
     'import/prefer-default-export': 'off',
+    'import/no-unresolved': 'off',
   },
   plugins: ['react', 'import', 'jsx-a11y', 'react-hooks'], // here we include the plugins as well, this is like new abilities for ESLint
   parserOptions: {

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Homepage.jsx
 - maps over carousels from configuration and renders each carousel
 - wraps all components in animations from framer-motion
 
+- Recommend components
+  - Trending Products
+
 SearchResultsPage.jsx
 
 - called by Main.jsx for route `/search`
@@ -104,7 +107,6 @@ You can define whether you want each attribute shown by adjusting `PDPHitSection
 - Recommend components
   - Related Products
   - Frequently Bought Together
-  - Trending Products
 
 <h2 style="font-family='Helvetica'; font-size=15px; font-weight=bold; color=grey;">🗳 Features Config</h2>
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ You can define whether you want each attribute shown by adjusting `PDPHitSection
 - Recommend components
   - Related Products
   - Frequently Bought Together
+  - Trending Products
 
 <h2 style="font-family='Helvetica'; font-size=15px; font-weight=bold; color=grey;">🗳 Features Config</h2>
 
@@ -256,7 +257,7 @@ To have the best UI, we defined the no results page with 3 parts:
 
 - First we just display the wrong query ex: yellow pant nike with an apologize message.
 - Secondly we incorporate the query suggestions to help the customer on navigation behaviour.
-- Third we stored, if the person already go on our website, his previous articles see. Them if he types a wrong query, we use Recomment and Related product with his last article seen, to create a carousel.
+- Third we stored, if the person already go on our website, his previous articles see. Them if he types a wrong query, we use Recommend and Related product with his last article seen, to create a carousel.
 
 <h3 style="font-family='Helvetica'; font-size=15px; font-weight=bold; color=grey;"> 👩‍💼🧑‍💼 Personas</h3>
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@algolia/react-instantsearch-widget-color-refinement-list": "^1.4.5",
     "@algolia/recommend": "^4.12.2",
     "@algolia/recommend-react": "^1.1.0",
+    "@algolia/ui-components-horizontal-slider-react": "^1.0.0",
     "@babel/eslint-parser": "^7.17.0",
     "@emotion/react": "^11.9.0",
     "@fortawesome/fontawesome-free": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@algolia/react-instantsearch-widget-color-refinement-list": "^1.4.5",
     "@algolia/recommend": "^4.12.2",
-    "@algolia/recommend-react": "^1.1.0",
+    "@algolia/recommend-react": "^1.3.1",
     "@algolia/ui-components-horizontal-slider-react": "^1.0.0",
     "@algolia/ui-components-horizontal-slider-theme": "^1.0.0",
     "@babel/eslint-parser": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@algolia/recommend": "^4.12.2",
     "@algolia/recommend-react": "^1.1.0",
     "@algolia/ui-components-horizontal-slider-react": "^1.0.0",
+    "@algolia/ui-components-horizontal-slider-theme": "^1.0.0",
     "@babel/eslint-parser": "^7.17.0",
     "@emotion/react": "^11.9.0",
     "@fortawesome/fontawesome-free": "^6.1.1",

--- a/src/config/featuresConfig.js
+++ b/src/config/featuresConfig.js
@@ -70,6 +70,11 @@ export const shouldHaveFbtProducts = atom({
   default: true, // default value (aka initial value)
 });
 
+export const shouldHaveTrendingProducts = atom({
+  key: 'shouldHaveTrendingProductsAtom', // unique ID (with respect to other atoms/selectors)
+  default: true, // default value (aka initial value)
+});
+
 export const shouldHaveDynamicFacet = atom({
   key: 'shouldHaveDynamicFacet', // unique ID (with respect to other atoms/selectors)
   default: true, // default value (aka initial value)

--- a/src/config/featuresConfig.js
+++ b/src/config/featuresConfig.js
@@ -70,6 +70,7 @@ export const shouldHaveFbtProducts = atom({
   default: true, // default value (aka initial value)
 });
 
+// this feature will be visible in the home page if activated -> (activated by default)
 export const shouldHaveTrendingProducts = atom({
   key: 'shouldHaveTrendingProductsAtom', // unique ID (with respect to other atoms/selectors)
   default: true, // default value (aka initial value)

--- a/src/config/trendingConfig.js
+++ b/src/config/trendingConfig.js
@@ -1,0 +1,6 @@
+// Config to customise the trending products carousel on home page
+export const trendingConfig = {
+    title: "Trending Products",
+    maxRecommendations: 10,
+    threshold: 2, // recommendations confidence score (between 0 and 100). Only recommendations with a greater score are returned.
+};

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,6 +1,7 @@
 // This is the homepage, which you see when you first visit the site.
 // By default it contains some banners and carousels
 
+// import algolia recommend
 import {
   TrendingItems,
 } from '@algolia/recommend-react';

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -2,10 +2,10 @@
 // By default it contains some banners and carousels
 
 // import algolia recommend
+import algoliarecommend from '@algolia/recommend';
 import {
   TrendingItems,
 } from '@algolia/recommend-react';
-import algoliarecommend from '@algolia/recommend';
 
 // Algolia search client
 import { searchClientCreds, mainIndex } from '@/config/algoliaEnvConfig';

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,6 +1,14 @@
 // This is the homepage, which you see when you first visit the site.
 // By default it contains some banners and carousels
 
+import {
+  TrendingItems,
+} from '@algolia/recommend-react';
+import algoliarecommend from '@algolia/recommend';
+
+// Algolia search client
+import { searchClientCreds, mainIndex } from '@/config/algoliaEnvConfig';
+
 import { lazy, Suspense, useRef, useEffect } from 'react';
 
 import Loader from '@/components/loader/Loader';
@@ -27,6 +35,9 @@ const FederatedSearch = lazy(() =>
   import('@/components/federatedSearch/FederatedSearch')
 );
 const HomeCarousel = lazy(() => import('@/components/carousels/HomeCarousel'));
+import RelatedItem from '@/components/recommend/RelatedProducts';
+import { HorizontalSlider } from '@algolia/ui-components-horizontal-slider-react';
+
 
 // should carousel be shown or not and config for carousel
 import { carouselConfig } from '@/config/carouselConfig';
@@ -35,16 +46,28 @@ import { carouselConfig } from '@/config/carouselConfig';
 import {
   shouldHaveFederatedSearch,
   shouldHaveCarousels,
+  shouldHaveTrendingProducts,
 } from '@/config/featuresConfig';
 
 import { shouldHaveOpenFederatedSearch } from '@/config/federatedConfig';
 
 const HomePage = ({ setIsMounted }) => {
+  // Get the main index
+  const index = useRecoilValue(mainIndex);
+
   // Boolean value which determines if federated search is shown or not, default is false
   const isFederated = useRecoilValue(shouldHaveFederatedSearch);
   const isCarousel = useRecoilValue(shouldHaveCarousels);
   const isFederatedOpen = useRecoilValue(shouldHaveOpenFederatedSearch);
   const HomePage = useRef(false);
+  const shouldHaveTrendingProductsValue = useRecoilValue(
+    shouldHaveTrendingProducts
+  );
+
+  const recommendClient = algoliarecommend(
+    searchClientCreds.appID,
+    searchClientCreds.APIKey
+  );
 
   useEffect(() => {
     HomePage.current = true;
@@ -94,6 +117,22 @@ const HomePage = ({ setIsMounted }) => {
             <HomeCarousel context={carousel.context} title={carousel.title} />
           </Suspense>
         ))}
+
+      {/* Render Recommend component - Trending Products */}
+      <div className="recommend">
+        {shouldHaveTrendingProductsValue && (
+          <div>
+            <h3>Trending Products</h3>
+            <TrendingItems
+              recommendClient={recommendClient}
+              indexName={index}
+              itemComponent={RelatedItem}
+              maxRecommendations={5}
+              view={HorizontalSlider}
+            />
+          </div>
+        )}
+      </div>
 
       {homepage_1 ? <img src={homepage_1} alt="" /> : null}
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -37,6 +37,7 @@ const FederatedSearch = lazy(() =>
 const HomeCarousel = lazy(() => import('@/components/carousels/HomeCarousel'));
 import RelatedItem from '@/components/recommend/RelatedProducts';
 import { HorizontalSlider } from '@algolia/ui-components-horizontal-slider-react';
+import '@algolia/ui-components-horizontal-slider-theme';
 
 
 // should carousel be shown or not and config for carousel

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -139,13 +139,12 @@ const HomePage = ({ setIsMounted }) => {
               itemComponent={RelatedItem}
               maxRecommendations={trendingConfig.maxRecommendations}
               view={HorizontalSlider}
-              headerComponent={TrendingSliderTitle}
+              headerComponent={() => <h3>{trendingConfig.title}</h3>}
               threshold={trendingConfig.threshold}
             />
           </div>
         )}
       </div>
-
 
       {homepage_1 ? <img src={homepage_1} alt="" /> : null}
 
@@ -153,15 +152,6 @@ const HomePage = ({ setIsMounted }) => {
     </motion.div>
   );
 };
-
-
-function TrendingSliderTitle() {
-  return (
-    <h3>
-      {trendingConfig.title}
-    </h3>
-  );
-}
 
 export default HomePage;
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -9,7 +9,7 @@ import algoliarecommend from '@algolia/recommend';
 // Algolia search client
 import { searchClientCreds, mainIndex } from '@/config/algoliaEnvConfig';
 
-import { lazy, Suspense, useRef, useEffect } from 'react';
+import React, { lazy, Suspense, useRef, useEffect } from 'react';
 
 import Loader from '@/components/loader/Loader';
 
@@ -51,6 +51,9 @@ import {
   shouldHaveCarousels,
   shouldHaveTrendingProducts,
 } from '@/config/featuresConfig';
+
+// trending carousel config
+import { trendingConfig } from '@/config/trendingConfig';
 
 import { shouldHaveOpenFederatedSearch } from '@/config/federatedConfig';
 
@@ -125,20 +128,23 @@ const HomePage = ({ setIsMounted }) => {
         ))}
 
       {/* Render Recommend component - Trending Products Slider */}
+      {/* Change header and maxRecommendations in /config/trendingConfig.js */}
       <div className="recommend">
         {shouldHaveTrendingProductsValue && (
           <div>
-            <h3>Trending Products</h3>
             <TrendingItems
               recommendClient={recommendClient}
               indexName={index}
               itemComponent={RelatedItem}
-              maxRecommendations={10}
+              maxRecommendations={trendingConfig.maxRecommendations}
               view={HorizontalSlider}
+              headerComponent={TrendingSliderTitle}
+              threshold={trendingConfig.threshold}
             />
           </div>
         )}
       </div>
+
 
       {homepage_1 ? <img src={homepage_1} alt="" /> : null}
 
@@ -147,4 +153,14 @@ const HomePage = ({ setIsMounted }) => {
   );
 };
 
+
+function TrendingSliderTitle() {
+  return (
+    <h3>
+      {trendingConfig.title}
+    </h3>
+  );
+}
+
 export default HomePage;
+

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -25,7 +25,6 @@ import { useRecoilValue } from 'recoil';
 import homepage_1 from '../assets/homepage/homepage_1.png';
 import homepage_2 from '../assets/homepage/homepage_2.png';
 
-import usePreventScrolling from '@/hooks/usePreventScrolling';
 
 // components import
 const CustomHomeBanners = lazy(() =>
@@ -36,7 +35,10 @@ const FederatedSearch = lazy(() =>
 );
 const HomeCarousel = lazy(() => import('@/components/carousels/HomeCarousel'));
 import RelatedItem from '@/components/recommend/RelatedProducts';
+
 import { HorizontalSlider } from '@algolia/ui-components-horizontal-slider-react';
+
+// styles for Recommend HorizontalSlider
 import '@algolia/ui-components-horizontal-slider-theme';
 
 
@@ -61,10 +63,13 @@ const HomePage = ({ setIsMounted }) => {
   const isCarousel = useRecoilValue(shouldHaveCarousels);
   const isFederatedOpen = useRecoilValue(shouldHaveOpenFederatedSearch);
   const HomePage = useRef(false);
+
+  // Boolean value which determines if federated search is shown or not, default is false
   const shouldHaveTrendingProductsValue = useRecoilValue(
     shouldHaveTrendingProducts
   );
 
+  // define the client for using Recommend
   const recommendClient = algoliarecommend(
     searchClientCreds.appID,
     searchClientCreds.APIKey
@@ -119,7 +124,7 @@ const HomePage = ({ setIsMounted }) => {
           </Suspense>
         ))}
 
-      {/* Render Recommend component - Trending Products */}
+      {/* Render Recommend component - Trending Products Slider */}
       <div className="recommend">
         {shouldHaveTrendingProductsValue && (
           <div>
@@ -128,7 +133,7 @@ const HomePage = ({ setIsMounted }) => {
               recommendClient={recommendClient}
               indexName={index}
               itemComponent={RelatedItem}
-              maxRecommendations={5}
+              maxRecommendations={10}
               view={HorizontalSlider}
             />
           </div>

--- a/src/pages/ProductDetails.jsx
+++ b/src/pages/ProductDetails.jsx
@@ -6,7 +6,6 @@ import algoliarecommend from '@algolia/recommend';
 import {
   RelatedProducts,
   FrequentlyBoughtTogether,
-  TrendingItems,
 } from '@algolia/recommend-react';
 
 // framer-motion
@@ -29,7 +28,6 @@ import { alertContent, isAlertOpen } from '@/config/demoGuideConfig';
 import {
   shouldHaveRelatedProducts,
   shouldHaveFbtProducts,
-  shouldHaveTrendingProducts,
 } from '@/config/featuresConfig';
 import { shouldHaveOpenFederatedSearch } from '@/config/federatedConfig';
 import { logoUrl as placeHolderError } from '@/config/headerConfig';
@@ -78,10 +76,6 @@ const ProductDetails = () => {
 
   const shouldHaveRelatedProductsValue = useRecoilValue(
     shouldHaveRelatedProducts
-  );
-
-  const shouldHaveTrendingProductsValue = useRecoilValue(
-    shouldHaveTrendingProducts
   );
 
   const shouldHaveFbtProductsValue = useRecoilValue(shouldHaveFbtProducts);

--- a/src/pages/ProductDetails.jsx
+++ b/src/pages/ProductDetails.jsx
@@ -2,47 +2,47 @@
 // It contains both Recommend components
 
 // Recommend
+import algoliarecommend from '@algolia/recommend';
 import {
   RelatedProducts,
   FrequentlyBoughtTogether,
   TrendingItems,
 } from '@algolia/recommend-react';
-import algoliarecommend from '@algolia/recommend';
 
 // framer-motion
 import { motion } from 'framer-motion';
+import get from 'lodash/get';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+
+import { ChevronLeft } from '@/assets/svg/SvgIndex';
+import Price from '@/components/price/price.jsx';
+import RelatedItem from '@/components/recommend/RelatedProducts';
+import { searchClientCreds, mainIndex } from '@/config/algoliaEnvConfig';
 import {
   framerMotionPage,
   framerMotionTransition,
 } from '@/config/animationConfig';
 
 // In case of img loading error
-import { logoUrl as placeHolderError } from '@/config/headerConfig';
-
-// Import components
-import { ChevronLeft } from '@/assets/svg/SvgIndex';
-import RelatedItem from '@/components/recommend/RelatedProducts';
-import Price from '@/components/price/price.jsx';
-
-// Algolia search client
-import { searchClientCreds, mainIndex } from '@/config/algoliaEnvConfig';
-
-import { HorizontalSlider } from '@algolia/ui-components-horizontal-slider-react';
-
-
-// React router import
-import { useNavigate } from 'react-router-dom';
-
-// Recoil import
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { hitAtom } from '@/config/hitsConfig';
+import { alertContent, isAlertOpen } from '@/config/demoGuideConfig';
 import {
   shouldHaveRelatedProducts,
   shouldHaveFbtProducts,
-  shouldHaveTrendingProducts
+  shouldHaveTrendingProducts,
 } from '@/config/featuresConfig';
-import { hitsConfig, PDPHitSections } from '@/config/hitsConfig';
 import { shouldHaveOpenFederatedSearch } from '@/config/federatedConfig';
+import { logoUrl as placeHolderError } from '@/config/headerConfig';
+
+// Import components
+
+// Algolia search client
+
+// React router import
+
+// Recoil import
+
+import { hitAtom, hitsConfig, PDPHitSections } from '@/config/hitsConfig';
 
 // Used to send insights event on add to cart
 import { personaSelectedAtom } from '@/config/personaConfig';
@@ -50,13 +50,10 @@ import { personaSelectedAtom } from '@/config/personaConfig';
 // Custom hooks
 import useScreenSize from '@/hooks/useScreenSize';
 
-import get from 'lodash/get';
-
 // Send an insights event to algolia
 import useSendAlgoliaEvent from '@/hooks/useSendAlgoliaEvent';
 
 // Used to show alert when add to cart event is sent
-import { alertContent, isAlertOpen } from '@/config/demoGuideConfig';
 
 const ProductDetails = () => {
   // For alert on sending add to cart event
@@ -259,20 +256,8 @@ const ProductDetails = () => {
           </motion.div>
         </div>
       </div>
-      {/* Render three Recommend components - Related Products, Frequently Bought Together, Trending Products */}
+      {/* Render two Recommend components - Related Products, Frequently Bought Together */}
       <div className="recommend">
-        {shouldHaveTrendingProductsValue && (
-          <div>
-            <h3>Trending Products</h3>
-            <TrendingItems
-              recommendClient={recommendClient}
-              indexName={index}
-              itemComponent={RelatedItem}
-              maxRecommendations={5}
-              view={HorizontalSlider}
-            />
-          </div>
-        )}
         {shouldHaveRelatedProductsValue && (
           <div>
             <h3>Related Products</h3>

--- a/src/pages/ProductDetails.jsx
+++ b/src/pages/ProductDetails.jsx
@@ -5,6 +5,7 @@
 import {
   RelatedProducts,
   FrequentlyBoughtTogether,
+  TrendingItems
 } from '@algolia/recommend-react';
 import algoliarecommend from '@algolia/recommend';
 
@@ -77,6 +78,9 @@ const ProductDetails = () => {
   const shouldHaveRelatedProductsValue = useRecoilValue(
     shouldHaveRelatedProducts
   );
+
+  const shouldHaveTrendingProductsValue = useRecoilValue(shouldHaveTrendingProducts);
+  
   const shouldHaveFbtProductsValue = useRecoilValue(shouldHaveFbtProducts);
 
   // Close federated and set value false for return without it
@@ -249,8 +253,18 @@ const ProductDetails = () => {
           </motion.div>
         </div>
       </div>
-      {/* Render both Recommend components- Related Products and Frequently Bought Together */}
+      {/* Render three Recommend components - Related Products, Frequently Bought Together, Trending Products */}
       <div className="recommend">
+      {shouldHaveTrendingProductsValue && (
+          <div>
+            <h3>Trending Products</h3>
+            <TrendingItems
+              recommendClient={recommendClient}
+              indexName={index}
+              itemComponent={RelatedItem}
+            />
+          </div>
+        )}
         {shouldHaveRelatedProductsValue && (
           <div>
             <h3>Related Products</h3>

--- a/src/pages/ProductDetails.jsx
+++ b/src/pages/ProductDetails.jsx
@@ -5,7 +5,7 @@
 import {
   RelatedProducts,
   FrequentlyBoughtTogether,
-  TrendingItems
+  TrendingItems,
 } from '@algolia/recommend-react';
 import algoliarecommend from '@algolia/recommend';
 
@@ -39,6 +39,7 @@ import {
 } from '@/config/featuresConfig';
 import { hitsConfig, PDPHitSections } from '@/config/hitsConfig';
 import { shouldHaveOpenFederatedSearch } from '@/config/federatedConfig';
+import { shouldHaveTrendingProducts } from '@/config/featuresConfig';
 
 // Used to send insights event on add to cart
 import { personaSelectedAtom } from '@/config/personaConfig';
@@ -79,8 +80,10 @@ const ProductDetails = () => {
     shouldHaveRelatedProducts
   );
 
-  const shouldHaveTrendingProductsValue = useRecoilValue(shouldHaveTrendingProducts);
-  
+  const shouldHaveTrendingProductsValue = useRecoilValue(
+    shouldHaveTrendingProducts
+  );
+
   const shouldHaveFbtProductsValue = useRecoilValue(shouldHaveFbtProducts);
 
   // Close federated and set value false for return without it
@@ -255,7 +258,7 @@ const ProductDetails = () => {
       </div>
       {/* Render three Recommend components - Related Products, Frequently Bought Together, Trending Products */}
       <div className="recommend">
-      {shouldHaveTrendingProductsValue && (
+        {shouldHaveTrendingProductsValue && (
           <div>
             <h3>Trending Products</h3>
             <TrendingItems

--- a/src/pages/ProductDetails.jsx
+++ b/src/pages/ProductDetails.jsx
@@ -265,6 +265,7 @@ const ProductDetails = () => {
               recommendClient={recommendClient}
               indexName={index}
               itemComponent={RelatedItem}
+              maxRecommendations={5}
             />
           </div>
         )}

--- a/src/pages/ProductDetails.jsx
+++ b/src/pages/ProductDetails.jsx
@@ -36,10 +36,10 @@ import { hitAtom } from '@/config/hitsConfig';
 import {
   shouldHaveRelatedProducts,
   shouldHaveFbtProducts,
+  shouldHaveTrendingProducts,
+  shouldHaveOpenFederatedSearch
 } from '@/config/featuresConfig';
 import { hitsConfig, PDPHitSections } from '@/config/hitsConfig';
-import { shouldHaveOpenFederatedSearch } from '@/config/federatedConfig';
-import { shouldHaveTrendingProducts } from '@/config/featuresConfig';
 
 // Used to send insights event on add to cart
 import { personaSelectedAtom } from '@/config/personaConfig';

--- a/src/pages/ProductDetails.jsx
+++ b/src/pages/ProductDetails.jsx
@@ -39,6 +39,7 @@ import {
   shouldHaveTrendingProducts,
   shouldHaveOpenFederatedSearch
 } from '@/config/featuresConfig';
+
 import { hitsConfig, PDPHitSections } from '@/config/hitsConfig';
 
 // Used to send insights event on add to cart

--- a/src/pages/ProductDetails.jsx
+++ b/src/pages/ProductDetails.jsx
@@ -27,6 +27,9 @@ import Price from '@/components/price/price.jsx';
 // Algolia search client
 import { searchClientCreds, mainIndex } from '@/config/algoliaEnvConfig';
 
+import { HorizontalSlider } from '@algolia/ui-components-horizontal-slider-react';
+
+
 // React router import
 import { useNavigate } from 'react-router-dom';
 
@@ -36,11 +39,10 @@ import { hitAtom } from '@/config/hitsConfig';
 import {
   shouldHaveRelatedProducts,
   shouldHaveFbtProducts,
-  shouldHaveTrendingProducts,
-  shouldHaveOpenFederatedSearch
+  shouldHaveTrendingProducts
 } from '@/config/featuresConfig';
-
 import { hitsConfig, PDPHitSections } from '@/config/hitsConfig';
+import { shouldHaveOpenFederatedSearch } from '@/config/federatedConfig';
 
 // Used to send insights event on add to cart
 import { personaSelectedAtom } from '@/config/personaConfig';
@@ -267,6 +269,7 @@ const ProductDetails = () => {
               indexName={index}
               itemComponent={RelatedItem}
               maxRecommendations={5}
+              view={HorizontalSlider}
             />
           </div>
         )}


### PR DESCRIPTION
## Objective
What: Trending Products Carousel on Product Page
Why: To show trending product recommendations inside a product page.
How: Using the Algolia Recommend TrendingItems, making it a configurable feature on the product page.
Usage: `shouldHaveTrendingProducts` in `/config/featuresConfig`

## Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance Tweaks
- [ ] Style Tweaks
- [ ] Code Refactoring
- [ ] Documentation
- [ ] Tests


## Tested

Outline the approach you've taken to test the change
Tested on localhost to see the feature in the product page when it is set to true and false.

## Documented

- [x] Have you documented in changed file using comments
- [x] Have you added instructions to the README if needed?
