### PR TITLE
Removed old logic to hide facets search input

### DIFF
--- a/src/components/facets/Facets.jsx
+++ b/src/components/facets/Facets.jsx
@@ -21,8 +21,8 @@ import { refinements } from '@/config/refinementsConfig';
 
 // expects an attribute which is an array of items
 const RefinementList = ({ title, items, refine, searchForItems, options }) => {
-  const [showFacet, setShowFacet] = useState(false);
   const [searchInput, setSearchInput] = useState(false);
+
   return (
     <div className="filters-container">
       <div className="filters-container__title">
@@ -42,11 +42,6 @@ const RefinementList = ({ title, items, refine, searchForItems, options }) => {
       <div className="filters-container__list">
         {searchInput && (
           <input
-            className={`${
-              showFacet
-                ? 'filters-container__list__search-facet'
-                : 'filters-container__list__search-facet__hidden'
-            }`}
             type="search"
             placeholder="Search"
             onChange={(event) => {

--- a/src/config/refinementsConfig.js
+++ b/src/config/refinementsConfig.js
@@ -36,6 +36,7 @@ export const refinements = [
     label: 'Brand',
     options: {
       attribute: hitsConfig.brand,
+      // when searchable is enabled, you can search for a specific value of that facet. Ex: Here you can search for a specific brand
       searchable: true,
     },
   },


### PR DESCRIPTION
## Objective
What: To refactor the logic that displays the facets on the search page 
Why: Code cleanup
How: Removed unused state and css class 
Usage: Alter the refinements config file to state which facets are searchable or not

## Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Tweaks
- [ ] Style Tweaks
- [x] Code Refactoring
- [ ] Documentation
- [ ] Tests


## Tested
Looked at the localhost and had Alex and Ben check that the logic was not in use anymore

## Documented

- [x] Have you documented in changed file using comments
- [x] Have you added instructions to the README if needed?
