### PR TITLE
fix: enable injected hits in production

### DIFF
--- a/src/components/searchresultpage/injected-hits/connectInjectedHits.jsx
+++ b/src/components/searchresultpage/injected-hits/connectInjectedHits.jsx
@@ -16,13 +16,13 @@ export const connectInjectedHits = createConnector({
     const resultsByIndex = isSingleIndex
       ? { [mainTargetedIndex]: { ...results, hits } }
       : Object.entries(results).reduce((acc, [indexName, indexResults]) => {
-          const isMainIndex = indexName === mainTargetedIndex;
+        const isMainIndex = indexName === mainTargetedIndex;
 
-          return {
-            ...acc,
-            [indexName]: isMainIndex ? { ...indexResults, hits } : indexResults,
-          };
-        }, {});
+        return {
+          ...acc,
+          [indexName]: isMainIndex ? { ...indexResults, hits } : indexResults,
+        };
+      }, {});
 
     const mainIndexHits = resultsByIndex[mainTargetedIndex]
       ? resultsByIndex[mainTargetedIndex].hits || []
@@ -43,9 +43,9 @@ export const connectInjectedHits = createConnector({
               const shouldInject =
                 typeof injectAt === 'function'
                   ? injectAt({
-                      ...slotScopeProps,
-                      hit,
-                    })
+                    ...slotScopeProps,
+                    hit,
+                  })
                   : position === injectAt;
 
               if (!shouldInject) {

--- a/src/config/featuresConfig.js
+++ b/src/config/featuresConfig.js
@@ -54,7 +54,7 @@ export const shouldHavePersona = atom({
 // Please see https://github.com/algolia/algolia-react-boilerplate#--injected-content for more info on injected content
 export const shouldHaveInjectedHits = atom({
   key: 'shouldHaveInjectedHits',
-  default: false,
+  default: true,
 });
 
 export const shouldHaveFederatedSearch = atom({


### PR DESCRIPTION
## Objective
What: Re-enable injected hits in production
Why: The production deployment is used for demos
How: Turn on feature flag default value
Usage: As normal but turn off when creating new demo

## Type
- [X] Bug Fix


## Tested
Ran locally

## Documented
NA
