### PR TITLE
Refactor resize listener

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,9 @@ import { BrowserRouter as Router } from 'react-router-dom';
 // Recoil State Management
 import { RecoilRoot } from 'recoil';
 
+// Resize component listens for screen size change to display UI accordingly
+import ScreenResizer from './utils/ScreenResizer';
+
 // SCSS import
 import './scss/index.scss';
 
@@ -13,6 +16,7 @@ const App = () => {
   return (
     <RecoilRoot>
       <Router>
+        <ScreenResizer />
         <Main />
       </Router>
     </RecoilRoot>

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -42,6 +42,7 @@ import usePreventScrolling from './hooks/usePreventScrolling';
 
 export const Main = () => {
   const index = useRecoilValue(mainIndex);
+
   const [isMounted, setIsMounted] = useState(false);
   // const [index, setIndex] = useState(mainIndex);
   const location = useLocation();

--- a/src/components/carousels/HomeCarousel.jsx
+++ b/src/components/carousels/HomeCarousel.jsx
@@ -16,12 +16,11 @@ import { segmentSelectedAtom } from '@/config/segmentConfig';
 // In case of img loading error
 import * as placeHolderError from '@/assets/logo/logo.webp';
 
-import useScreenSize from '@/hooks/useScreenSize';
-
 import get from 'lodash/get';
 
 // import Price component
 import Price from '@/components/hits/components/Price.jsx';
+import { windowSize } from '@/hooks/useScreenSize';
 
 //Import scope SCSS
 import './SCSS/carousels.scss';
@@ -32,7 +31,8 @@ const HomeCarousel = ({ context, title }) => {
   const userToken = useRecoilValue(personaSelectedAtom);
   const segmentOptionalFilters = useRecoilValue(segmentSelectedAtom);
 
-  const { mobile } = useScreenSize();
+  const { mobile } = useRecoilValue(windowSize);
+
   return (
     <div className={`${mobile ? 'home-carousel-mobile' : 'home-carousel'}`}>
       <Index indexId={title} indexName={index}>

--- a/src/components/demoGuide/DemoGuide.jsx
+++ b/src/components/demoGuide/DemoGuide.jsx
@@ -12,7 +12,7 @@ import SearchTerms from './components/SearchTerms';
 
 //Import Hooks
 import useOutsideClickConditional from '@/hooks/useOutsideClickConditional';
-import useScreenSize from '@/hooks/useScreenSize';
+import { windowSize } from '@/hooks/useScreenSize';
 
 //Import custom transition for panel animations
 import { framerMotionTransition } from '@/config/animationConfig';
@@ -53,7 +53,7 @@ const DemoGuide = ({ setshowDemoGuide }) => {
   const demoGuideBtn = useRecoilValue(demoGuideBtnRef);
 
   //Listen for screen resize
-  const { tablet, mobile } = useScreenSize();
+  const { tablet, mobile } = useRecoilValue(windowSize);
 
   //Listen for click outside the Demo Guide panel
   useOutsideClickConditional(demoGuide, demoGuideBtn, () =>

--- a/src/components/federatedSearch/FederatedSearch.jsx
+++ b/src/components/federatedSearch/FederatedSearch.jsx
@@ -37,7 +37,7 @@ import { selectorNavigationRef } from '@/config/headerConfig';
 // Check if user is clecking outside an element
 import useOutsideClickTwoConditionals from '@/hooks/useOutsideClickTwoConditions';
 // Check screensize for responsiveness
-import useScreenSize from '@/hooks/useScreenSize';
+import { windowSize } from '@/hooks/useScreenSize';
 
 // Components imports
 import Redirect from '@/components/redirects/Redirect';
@@ -69,7 +69,7 @@ const FederatedSearch = () => {
     useRecoilState(federatedRef);
 
   // Get screen size
-  const { mobile, tablet } = useScreenSize();
+  const { mobile, tablet } = useRecoilValue(windowSize);
 
   // Custom hook
 

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -2,7 +2,8 @@
 import { memo } from 'react';
 
 // Import Hook for a Sticky Header
-import useScreenSize from '@/hooks/useScreenSize';
+import { windowSize } from '@/hooks/useScreenSize';
+import { useRecoilValue } from 'recoil';
 
 // Import 2 kind of Headers
 import HeaderLaptop from '@/components/header/components/HeaderLaptop';
@@ -13,7 +14,7 @@ import './SCSS/header.scss';
 
 const Header = () => {
   // Handle screen sizing & responsiveness with this hook
-  const { mobile, tablet, laptopXS, laptop } = useScreenSize();
+  const { mobile, tablet, laptopXS, laptop } = useRecoilValue(windowSize);
 
   // Render the Header for Laptop or Mobile, depending on the size of the screen
   return (

--- a/src/components/hits/HitsSkeletonLoader.jsx
+++ b/src/components/hits/HitsSkeletonLoader.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import useScreenSize from '@/hooks/useScreenSize';
+import { windowSize } from '@/hooks/useScreenSize';
 import CustomSkeleton from '@/components/skeletons/CustomSkeleton';
+import { useRecoilValue } from 'recoil';
 
 const SkeletonLoader = ({type}) => {
-  const { tablet, mobile } = useScreenSize();
+  const { tablet, mobile } = useRecoilValue(windowSize);;
 
   // Change this number to render more placeholders on the SRP loader
   const resultsNumber = 20;

--- a/src/components/hits/components/HitsSkeletonLoader.jsx
+++ b/src/components/hits/components/HitsSkeletonLoader.jsx
@@ -1,8 +1,9 @@
-import useScreenSize from '@/hooks/useScreenSize';
 import CustomSkeleton from '@/components/skeletons/CustomSkeleton';
+import { windowSize } from '@/hooks/useScreenSize';
+import { useRecoilValue } from 'recoil';
 
 const SkeletonLoader = ({type}) => {
-  const { tablet, mobile } = useScreenSize();
+  const { tablet, mobile } = useRecoilValue(windowSize);
 
   // Change this number to render more placeholders on the SRP loader
   const resultsNumber = 20;

--- a/src/hooks/useScreenSize.jsx
+++ b/src/hooks/useScreenSize.jsx
@@ -1,37 +1,12 @@
+import { atom } from 'recoil';
+
 // This is for defining the size of the window, for responsive design
-
-import { useState, useEffect } from 'react';
-
-const useScreenSize = () => {
-  const [windowSize, setWindowSize] = useState({
+export const windowSize = atom({
+  key: 'windowSize', // unique ID (with respect to other atoms/selectors)
+  default: {
     laptop: undefined,
     laptopXS: undefined,
     tablet: undefined,
     mobile: undefined,
-  });
-  
-  useEffect(() => {
-    const handleResize = () => {
-      // Set screen size and return true or false
-      setWindowSize({
-        laptop: window.innerWidth >= 1440,
-        laptopXS: window.innerWidth > 768 && window.innerWidth < 1440,
-        tablet: window.innerWidth >= 480 && window.innerWidth <= 768,
-        mobile: window.innerWidth < 480,
-      });
-    };
-
-    // Add event listener
-    window.addEventListener('resize', handleResize);
-
-    // Call handler right away so state gets updated with initial window size
-    handleResize();
-
-    // Remove event listener on cleanup
-    return () => window.removeEventListener('resize', handleResize);
-  }, []); // Empty array ensures that effect is only run on mount
-
-  return windowSize;
-};
-
-export default useScreenSize;
+  }, // default value (aka initial value)
+});

--- a/src/hooks/useScreenSize.jsx
+++ b/src/hooks/useScreenSize.jsx
@@ -9,25 +9,28 @@ const useScreenSize = () => {
     tablet: undefined,
     mobile: undefined,
   });
+  
   useEffect(() => {
     const handleResize = () => {
       // Set screen size and return true or false
       setWindowSize({
-        laptop: window.innerWidth >= 1440 ? true : false,
-        laptopXS:
-          window.innerWidth > 768 && window.innerWidth < 1440 ? true : false,
-        tablet:
-          window.innerWidth >= 480 && window.innerWidth <= 768 ? true : false,
-        mobile: window.innerWidth < 480 ? true : false,
+        laptop: window.innerWidth >= 1440,
+        laptopXS: window.innerWidth > 768 && window.innerWidth < 1440,
+        tablet: window.innerWidth >= 480 && window.innerWidth <= 768,
+        mobile: window.innerWidth < 480,
       });
     };
+
     // Add event listener
     window.addEventListener('resize', handleResize);
+
     // Call handler right away so state gets updated with initial window size
     handleResize();
+
     // Remove event listener on cleanup
     return () => window.removeEventListener('resize', handleResize);
   }, []); // Empty array ensures that effect is only run on mount
+
   return windowSize;
 };
 

--- a/src/pages/productDetailsPage/ProductDetails.jsx
+++ b/src/pages/productDetailsPage/ProductDetails.jsx
@@ -46,7 +46,7 @@ import { hitAtom, hitsConfig, PDPHitSections } from '@/config/hitsConfig';
 import { personaSelectedAtom } from '@/config/personaConfig';
 
 // Custom hooks
-import useScreenSize from '@/hooks/useScreenSize';
+import { windowSize } from '@/hooks/useScreenSize';
 
 // Send an insights event to algolia
 import useSendAlgoliaEvent from '@/hooks/useSendAlgoliaEvent';
@@ -94,7 +94,7 @@ const ProductDetails = () => {
     searchClientCreds.APIKey
   );
 
-  const { tablet, mobile } = useScreenSize();
+  const { tablet, mobile } = useRecoilValue(windowSize);
 
   // Get hit attribute from config file
   const {

--- a/src/utils/ScreenResizer.jsx
+++ b/src/utils/ScreenResizer.jsx
@@ -1,0 +1,34 @@
+import { useSetRecoilState } from 'recoil';
+
+import { useEffect } from 'react';
+import { windowSize } from '@/hooks/useScreenSize';
+
+const ScreenResizer = () => {
+
+    const setWindowSize = useSetRecoilState(windowSize);
+
+    const handleResize = () => {
+      // Set screen size and return true or false
+      setWindowSize({
+        laptop: window.innerWidth >= 1440,
+        laptopXS: window.innerWidth > 768 && window.innerWidth < 1440,
+        tablet: window.innerWidth >= 480 && window.innerWidth <= 768,
+        mobile: window.innerWidth < 480,
+      });
+    };
+  
+    useEffect(() => {
+      // Add event listener
+      window.addEventListener('resize', handleResize);
+  
+      // Call handler right away so state gets updated with initial window size
+      handleResize();
+      
+      // Remove event listener on cleanup
+      return () => window.removeEventListener('resize', handleResize);
+    }, []); // Empty array ensures that effect is only run on mount
+
+    return <></>
+}
+
+export default ScreenResizer;


### PR DESCRIPTION
## Objective
What: https://github.com/algolia/algolia-react-boilerplate/issues/260
Why: So that the window does not overload with listeners, this shares the same one
How: Switching from a hook to global state
Usage: you call `useRecoilValue(windowSize)`

## Type

- [x] Performance Tweaks
- [x] Code Refactoring


## Tested

Localhost + Console

## Documented

- [x] Have you documented in changed file using comments
