### PR TITLE
Fix/pdp single load

### DIFF
--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -44,7 +44,6 @@ export const Main = () => {
   const index = useRecoilValue(mainIndex);
 
   const [isMounted, setIsMounted] = useState(false);
-  // const [index, setIndex] = useState(mainIndex);
   const location = useLocation();
 
   // Should the alert badges for the demo guide be shown


### PR DESCRIPTION
## Objective
What: Make sure to load in hit for PDP before displaying relevant content, use recommend hooks
Why: So user can load a PDP from a link, and so recommendations modals only show if there are any
How: Use API client instance to search by ObjectID if hit is not already stored, and use the recommend hooks
Usage: As normal

## Type
- [X] Bug Fix
- [X] Code Refactoring



## Tested
Ran locally


## Documented

- [X] Have you documented in changed file using comments
- [ ] Have you added instructions to the README if needed?
