### PR TITLE
Feat/276 perso filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,13 @@ To have the best UI, we defined the no results page with 3 parts:
 
 [Personalization](https://www.algolia.com/doc/guides/personalization/what-is-personalization/)
 
-To configure personalisation please first make sure you have user profiles created in Algolia with their respective user tokens.
+To configure personalisation please first make sure you have the Personalization feature enabled on your plan, and that you have the correct strategy created. For example, if you want to boost colour: blue for a persona, you need to make sure that colour is in your strategy as a facet.
 
-Then, you can visit `config/personaConfig` and update the `value`s to match the user tokens you need to send. The `description` will also show up in the demo guide component.
+Then, you can visit `config/personaConfig` and update the `value`s to match the user tokens you need to send, and update the personalizationFilters array to contain the attributes and values you want to boost for each persona. The `description` will also show up in the demo guide component.
+
+You can also adjust the personalizationImpact number in `config/personaConfig` to control how much personalization applies to the results where personalization is turned on.
+
+Personalization is currently active by default in the search results page, and in the main section (normally products) of the federated search.
 
 The current user stories are:
 

--- a/src/components/federatedSearch/FederatedSearch.jsx
+++ b/src/components/federatedSearch/FederatedSearch.jsx
@@ -25,7 +25,7 @@ import {
 import { queryAtom, searchBoxAtom } from '@/config/searchboxConfig';
 
 // Import Persona State from recoil
-import { personaSelectedAtom } from '@/config/personaConfig';
+import { personalizationImpact, personaSelectedAtom, personaSelectedFiltersAtom } from '@/config/personaConfig';
 
 // Import Segment State from recoil
 import { segmentSelectedAtom } from '@/config/segmentConfig';
@@ -51,8 +51,11 @@ import RecentSearches from './components/RecentSearches';
 import './SCSS/federatedSearch.scss';
 
 const FederatedSearch = () => {
-  // Recoil & States
+  // Persona
   const personaSelect = useRecoilValue(personaSelectedAtom);
+  const personalizationFilters = useRecoilValue(personaSelectedFiltersAtom);
+
+
   const segmentSelect = useRecoilValue(segmentSelectedAtom);
   const setIsFederated = useSetRecoilState(shouldHaveOpenFederatedSearch);
   const searchboxRef = useRecoilValue(searchBoxAtom);
@@ -99,9 +102,8 @@ const FederatedSearch = () => {
 
   return (
     <div
-      className={`${
-        mobile || tablet ? 'federatedSearch-mobile' : 'federatedSearch'
-      }`}
+      className={`${mobile || tablet ? 'federatedSearch-mobile' : 'federatedSearch'
+        }`}
       ref={setContainerFederated}
       variants={framerMotionFederatedContainer}
       initial={framerMotionFederatedContainer.initial}
@@ -113,11 +115,10 @@ const FederatedSearch = () => {
         &lsaquo; Return to Homepage
       </span>
       <div
-        className={`${
-          mobile || tablet
-            ? 'federatedSearch__wrapper-mobile'
-            : 'federatedSearch__wrapper'
-        }`}
+        className={`${mobile || tablet
+          ? 'federatedSearch__wrapper-mobile'
+          : 'federatedSearch__wrapper'
+          }`}
       >
         <div className="federatedSearch__left">
           {/* If don't want this sections go into config file  */}
@@ -130,6 +131,8 @@ const FederatedSearch = () => {
                 query={query}
                 userToken={personaSelect}
                 enablePersonalization={true}
+                personalizationImpact={personalizationImpact}
+                personalizationFilters={personalizationFilters}
               />
               <QuerySuggestions />
             </Index>
@@ -145,9 +148,11 @@ const FederatedSearch = () => {
             <Configure
               filters=""
               hitsPerPage={6}
-              userToken={personaSelect}
-              optionalFilters={segmentSelect}
               enablePersonalization={true}
+              userToken={personaSelect}
+              personalizationImpact={personalizationImpact}
+              personalizationFilters={personalizationFilters}
+              optionalFilters={segmentSelect}
               query={query}
             />
             <Products />

--- a/src/components/header/components/personnaSelect/SelectPersona.jsx
+++ b/src/components/header/components/personnaSelect/SelectPersona.jsx
@@ -14,10 +14,14 @@ import { useRecoilState } from 'recoil';
 import {
   personaConfig,
   personaSelectedAtom,
+  personaSelectedFiltersAtom,
   styles,
 } from '@/config/personaConfig';
 
 const SelectPersona = () => {
+
+  const [personaSelectedFiltersSelected, setPersonaSelectedFilters] = useRecoilState(personaSelectedFiltersAtom)
+
   const [personaSelected, setPersonaSelect] =
     useRecoilState(personaSelectedAtom);
 
@@ -33,6 +37,7 @@ const SelectPersona = () => {
       placeholder="No Persona"
       onChange={(e) => {
         setPersonaSelect(e.value);
+        setPersonaSelectedFilters(e.personalizationFilters)
       }}
     />
   );

--- a/src/components/searchresultpage/srpLaptop/SrpLaptop.jsx
+++ b/src/components/searchresultpage/srpLaptop/SrpLaptop.jsx
@@ -24,7 +24,7 @@ import {
   shouldHaveTrendingProducts,
 } from '@/config/featuresConfig';
 import { hitsPerPage } from '@/config/hitsConfig';
-import { personaSelectedAtom } from '@/config/personaConfig';
+import { personalizationImpact, personaSelectedAtom, personaSelectedFiltersAtom } from '@/config/personaConfig';
 import { queryAtom } from '@/config/searchboxConfig';
 import { segmentSelectedAtom } from '@/config/segmentConfig';
 import { sortBy } from '@/config/sortByConfig';
@@ -73,6 +73,7 @@ const SrpLaptop = () => {
 
   // Persona
   const userToken = useRecoilValue(personaSelectedAtom);
+  const personalizationFilters = useRecoilValue(personaSelectedFiltersAtom);
 
   // Segments
   const segmentOptionalFilters = useRecoilValue(segmentSelectedAtom);
@@ -150,8 +151,10 @@ const SrpLaptop = () => {
               injected ? hitsPerPageInjected : hitsPerPageNotInjected
             }
             analytics={false}
-            userToken={userToken}
             enablePersonalization={true}
+            userToken={userToken}
+            personalizationImpact={personalizationImpact}
+            personalizationFilters={personalizationFilters}
             filters={
               state?.type === 'filter' && state?.action !== null
                 ? state.action

--- a/src/components/searchresultpage/srpMobile/SrpMobile.jsx
+++ b/src/components/searchresultpage/srpMobile/SrpMobile.jsx
@@ -31,7 +31,7 @@ import {
   shouldHaveTrendingFacets,
 } from '@/config/featuresConfig';
 import { hitsPerPage } from '@/config/hitsConfig';
-import { personaSelectedAtom } from '@/config/personaConfig';
+import { personalizationImpact, personaSelectedAtom, personaSelectedFiltersAtom } from '@/config/personaConfig';
 import { queryAtom } from '@/config/searchboxConfig';
 import { segmentSelectedAtom } from '@/config/segmentConfig';
 import { sortBy } from '@/config/sortByConfig';
@@ -87,6 +87,7 @@ const SrpMobile = () => {
 
   // Persona
   const userToken = useRecoilValue(personaSelectedAtom);
+  const personalizationFilters = useRecoilValue(personaSelectedFiltersAtom);
 
   // Segments
   const segmentOptionalFilters = useRecoilValue(segmentSelectedAtom);
@@ -116,9 +117,8 @@ const SrpMobile = () => {
       <div
         role="menu"
         tabIndex={0}
-        className={`${
-          isMenuOpen ? 'facets-slider-active' : 'facets-slider-inactive'
-        } facets-slider`}
+        className={`${isMenuOpen ? 'facets-slider-active' : 'facets-slider-inactive'
+          } facets-slider`}
         onClick={() => {
           setIsMenuOpen(!isMenuOpen);
         }}
@@ -159,8 +159,10 @@ const SrpMobile = () => {
         <Configure
           hitsPerPage={injected ? hitsPerPageInjected : hitsPerPageNotInjected}
           analytics={false}
-          userToken={userToken}
           enablePersonalization={true}
+          userToken={userToken}
+          personalizationImpact={personalizationImpact}
+          personalizationFilters={personalizationFilters}
           filters={
             state?.type === 'filter' && state?.action !== null
               ? state.action
@@ -179,7 +181,7 @@ const SrpMobile = () => {
             <TrendingFacetValues
               facetName={facetName}
               facetValue={facetValue}
-               attribute="brand"
+              attribute="brand"
             />
           )}
         </div>

--- a/src/config/personaConfig.js
+++ b/src/config/personaConfig.js
@@ -9,8 +9,9 @@ export const personalizationImpact = 98
 // This const defines the personas available for personalisation
 // The labels will show in a dropdown in the navigation
 // The values are what is sent as the userToken to Algolia
-// Add or remove objects to this array as you see fit
-// Just make sure you have events and profiles for your values
+// The personalizationFilters will fake perso profiles at query time so you don't need to send events
+// You do however need to have perso feature enabled on the plan, and the strategy created
+// Add or remove objects to the personaConfig array as you see fit
 // ------------------------------------------
 export const personaConfig = [
   { value: 'anon', label: 'No Persona', description: 'Anonymous user', personalizationFilters: [] },
@@ -18,13 +19,13 @@ export const personaConfig = [
     value: 'stephen_james',
     label: 'Stephen',
     description: 'Stephen James is a man who likes sports shoes',
-    personalizationFilters: []
+    personalizationFilters: ["genderFilter:men<score=1>", "hierarchicalCategories.lvl2:'Mens > Shoes'<score=1>"]
   },
   {
     value: 'elizabeth_aniston',
     label: 'Elizabeth',
     description: 'Elizabeth is a woman who likes blue dresses',
-    personalizationfilters: []
+    personalizationfilters: ["colour:blue<score=1>", "genderFilter:women<score=1>", "hierarchicalCategories.lvl2:'Womens > Clothing > Dresses'<score=1>"]
   },
 ];
 

--- a/src/config/personaConfig.js
+++ b/src/config/personaConfig.js
@@ -3,6 +3,8 @@
 // ------------------------------------------
 import { atom } from 'recoil';
 
+export const personalizationImpact = 98
+
 // ------------------------------------------
 // This const defines the personas available for personalisation
 // The labels will show in a dropdown in the navigation
@@ -11,18 +13,37 @@ import { atom } from 'recoil';
 // Just make sure you have events and profiles for your values
 // ------------------------------------------
 export const personaConfig = [
-  { value: 'anon', label: 'No Persona', description: 'Anonymous user' },
+  { value: 'anon', label: 'No Persona', description: 'Anonymous user', personalizationFilters: [] },
   {
     value: 'stephen_james',
     label: 'Stephen',
     description: 'Stephen James is a man who likes sports shoes',
+    personalizationFilters: []
   },
   {
     value: 'elizabeth_aniston',
     label: 'Elizabeth',
     description: 'Elizabeth is a woman who likes blue dresses',
+    personalizationfilters: []
   },
 ];
+
+// Please ignore this atom
+export const personaSelectedAtom = atom({
+  key: 'personaSelected', // unique ID (with respect to other atoms/selectors)
+  default: personaConfig[0].value, // default value (aka initial value)
+});
+
+export const personaSelectedFiltersAtom = atom({
+  key: 'personaFiltersSelected', // unique ID (with respect to other atoms/selectors)
+  default: personaConfig[0].personalizationFilters, // default value (aka initial value)
+});
+
+// Please ignore this atom
+export const isPersonaMenuOpen = atom({
+  key: 'isPersonaMenuOpen', // unique ID (with respect to other atoms/selectors)
+  default: false, // default value (aka initial value)
+});
 
 // Styles for persona selection dropdown, please ignore
 export const styles = {
@@ -98,15 +119,3 @@ export const styles = {
     color: 'black',
   }),
 };
-
-// Please ignore this atom
-export const personaSelectedAtom = atom({
-  key: 'personaSelected', // unique ID (with respect to other atoms/selectors)
-  default: personaConfig[0].value, // default value (aka initial value)
-});
-
-// Please ignore this atom
-export const isPersonaMenuOpen = atom({
-  key: 'isPersonaMenuOpen', // unique ID (with respect to other atoms/selectors)
-  default: false, // default value (aka initial value)
-});


### PR DESCRIPTION
## Objective
What: Allow SE's to fake user profiles at query time
Why: Avoids sending many fake events for each persona
How: Added personalizationFilters and personalizationImpact to configures and to config
Usage: Use README, adjust personaConfig as needed

## Type
- [X] New Feature
- [X] Code Refactoring


## Tested
Ran locally, tried for Valentino demo


## Documented
- [X] Have you documented in changed file using comments
- [X] Have you added instructions to the README if needed?
