### PR TITLE
chore: add deploy to netlify button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # React Boilerplate for Custom Demos
 
+[![Deploy To Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/algolia/algolia-react-boilerplate)
+
+
 - [Get started](#️-get-started)
 - [Structure](#️-structure)
 - [Features Config](#-features-config)


### PR DESCRIPTION
## Objective
What: Adds a button to deploy a version of the template directly to netlify
Why: Easier to create a separate instance of the default boilerplate
How: https://docs.netlify.com/site-deploys/create-deploys/
Usage: Click the button in the README

## Type
N/A

## Tested
README preview


## Documented
- [X] Have you added instructions to the README if needed?
