### PR TITLE
chore: correct port

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 1. Clone this repo under a new name for your own demo.
 
-2. Run `yarn install` in the root directory and `yarn start` to view your project on [http://localhost:3000](http://localhost:3000/)
+2. Run `yarn` in the root directory and `yarn start` to view your project on [http://localhost:5173](http://localhost:5173/)
 
 3. Visit `src/config` and adjust `algoliaEnvConfig` to point to your own app, indices and API keys. If you do not need an index which is present in that file i.e. for articles, please do not remove it, just leave it as is, and you can turn off the relevant feature in the next step.
 


### PR DESCRIPTION
## Objective
Vite 3 runs by default on port 5173, document this

## Type
- [X] Documentation

## Tested
NA

## Documented
- [X] Have you added instructions to the README if needed?
