### PR TITLE
fix: only show demo guide opener if feature flag is turned on

### DIFF
--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -21,9 +21,9 @@ import { queryAtom } from './config/searchboxConfig';
 import {
   isDemoGuideOpen,
   shouldShowAlert,
-  shouldShowDemoGuide,
   showNetworkErorrs,
 } from '@/config/demoGuideConfig';
+import { shouldHaveDemoGuide } from '@/config/featuresConfig';
 import { isCarouselLoaded } from './config/carouselConfig';
 
 // Import Pages and static components
@@ -57,10 +57,10 @@ export const Main = () => {
   // Show rules applied panel when switch on in the demo guide panel
   const isRulesSwitchToggleChecked = useRecoilValue(isRulesSwitchToggle);
 
-  // Show the feature of guided panel for SE should be in this app
-  const shouldShowNavigation = useRecoilValue(shouldShowDemoGuide);
+  // Show guided panel for SE
+  const shouldHaveDemoGuideAtom = useRecoilValue(shouldHaveDemoGuide);
 
-  // State that show/hide the panel if click on the guide btn
+  // Show/hide the panel if click on the guide btn
   const [showDemoGuide, setshowDemoGuide] = useRecoilState(isDemoGuideOpen);
 
   // Value that shows Network Errors to Guide you to the correct Configuration
@@ -69,6 +69,7 @@ export const Main = () => {
   // Prevent body from scrolling when panel is open
   usePreventScrolling(showDemoGuide);
 
+
   return (
     <InstantSearch searchClient={searchClient} indexName={index}>
       {isNetworkErorrs && <SearchErrorToast />}
@@ -76,9 +77,9 @@ export const Main = () => {
       <div className="visible">
         <Configure query={queryState} />
         <Header />
-        <DemoGuideOpener />
+        {shouldHaveDemoGuideAtom && <DemoGuideOpener />}
         <AnimatePresence>
-          {showDemoGuide && shouldShowNavigation && (
+          {showDemoGuide && (
             <DemoGuide setshowDemoGuide={setshowDemoGuide} />
           )}
         </AnimatePresence>

--- a/src/config/demoGuideConfig.js
+++ b/src/config/demoGuideConfig.js
@@ -3,12 +3,6 @@ import { atom } from 'recoil';
 // import personaConfig for displaying in the guide
 import { personaConfig } from './personaConfig';
 
-// Should we show the demo guide in this demo
-export const shouldShowDemoGuide = atom({
-  key: 'shouldShowDemoGuide',
-  default: true,
-});
-
 // Should we show the network errors in the demo - might want to switch this to false when demo-ing to a client
 export const showNetworkErorrs = atom({
   key: 'showNetworkErorrs',

--- a/src/config/featuresConfig.js
+++ b/src/config/featuresConfig.js
@@ -8,6 +8,14 @@ import { atom } from 'recoil';
 // TODO: add perso and other features here including what to have on federated
 // ------------------------------------------
 
+
+// Should we show the demo guide in this demo
+export const shouldHaveDemoGuide = atom({
+  key: 'shouldHaveDemoGuide',
+  default: true,
+});
+
+
 // Should the segment selector be displayed on the screen
 export const shouldHaveSegments = atom({
   key: 'shouldHaveSegments', // unique ID (with respect to other atoms/selectors)


### PR DESCRIPTION
## Objective
What: Demo guide was always shown, fix this
Why: For obvious reasons, SE doesn't always want it shown
How: featuresConfig and conditionals
Usage: as normal, featuresConfig

## Type
- [X] Bug Fix

## Tested
Ran local for both cases

## Documented
- [X] Have you documented in changed file using comments
- [ ] Have you added instructions to the README if needed?
