### PR TITLE
fix: too much margin

### DIFF
--- a/src/components/selector/selectors.scss
+++ b/src/components/selector/selectors.scss
@@ -33,7 +33,6 @@
         pointer-events: none;
         z-index: 99;
         transition: all 0.2s ease-in-out;
-        margin-top: 3rem;
     }
  
     .active{
@@ -41,7 +40,6 @@
         opacity: 1;
         top: 3rem;
         transition: all 0.3s ease-in-out;
-        margin-top: 4rem !important;
     }
 
     &__listItem{


### PR DESCRIPTION
## Objective
What: Fixed a margin top on selectors
Why:

How: 
<img width="513" alt="Screenshot 2022-09-12 at 10 36 10" src="https://user-images.githubusercontent.com/22235112/189610156-667734ee-737c-441b-96b8-015af7932d7e.png">

Usage:

## Type

- [x] Bug Fix


![screencapture-localhost-5173-search-2022-09-12-10_40_09](https://user-images.githubusercontent.com/22235112/189610188-19158b1b-c660-4175-91e0-a32eca4ebdec.png)
