### PR TITLE
fix: query was "null" due to reading from url state

### DIFF
--- a/src/components/searchresultpage/SearchResults/SearchResults.jsx
+++ b/src/components/searchresultpage/SearchResults/SearchResults.jsx
@@ -203,7 +203,7 @@ const SearchResults = () => {
             ruleContexts={
               navigationState?.type === 'context' ? navigationState.action : ''
             }
-            query={searchParams.get('query')}
+            query={searchParams.get('query') === null ? '' : searchParams.get('query')}
             getRankingInfo={true}
           />
 


### PR DESCRIPTION
## Objective
What: Stop query being "null" by default
Why:
How: 
Usage:

## Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Tweaks
- [ ] Style Tweaks
- [ ] Code Refactoring
- [ ] Documentation
- [ ] Tests


## Tested

Outline the approach you've taken to test the change

## Translation

- [ ] Have you translated all your Paragraphs, ButtonsTitle,... with i18n functionality?

## Documented

- [ ] Have you documented in changed file using comments
- [ ] Have you added instructions to the README if needed?
