### PR TITLE
feat: add predict to the app through a provider, with a default user ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [Get started](#️-get-started)
 - [Structure](#️-structure)
 - [Features Config](#-features-config)
+  - [ Predict](#--predict)
   - [ Redirects](#--redirects)
   - [ Federated Search](#--federated-search)
   - [ Voice Search](#--voice-search)
@@ -130,6 +131,16 @@ You can define whether you want each attribute shown by adjusting `PDPHitSection
   - Frequently Bought Together
 
 <h2 style="font-family='Helvetica'; font-size=15px; font-weight=bold; color=grey;">🗳 Features Config</h2>
+
+<h3 style="font-family='Helvetica'; font-size=15px; font-weight=bold; color=grey;"> 🔮 Predict</h3>
+
+The app has access to predict through the PredictUserProfileProvider component, found in `./src/components/predict`.
+
+In order for predict to function, it must have a predict App ID, API key and region set in algoliaEnvConfig, found in `./src/config`. Please contact Algolia if you are not sure what values they should have.
+
+You must also adjust the values found in `src/config/predictConfig`. We store a default value for `predictUserIdAtom` to ensure the app works with the default demo flow, but you should replace it with your own predict user ID for your own demo purposes.
+
+You can feel free to keep the default values for all of these atoms and configurations, and follow the default demo flow outlined below (TBD).
 
 <h3 style="font-family='Helvetica'; font-size=15px; font-weight=bold; color=grey;"> 👀 Demo Tour</h3>
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   },
   "homepage": "https://github.com/algolia/algolia-react-boilerplate#readme",
   "dependencies": {
+    "@algolia/predict": "1.0.0-alpha.26",
+    "@algolia/predict-react": "^1.3.0",
     "@algolia/recommend": "^4.12.2",
     "@algolia/recommend-react": "^1.4.0",
     "@algolia/ui-components-horizontal-slider-react": "^1.0.0",

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { lazy, useEffect, Suspense } from 'react';
 
 // Algolia Instantsearch components
 import { Configure, InstantSearch } from 'react-instantsearch-hooks-web';
@@ -26,10 +26,11 @@ import {
   shouldHaveCartFunctionality,
   shouldHaveDemoGuide,
 } from '@/config/featuresConfig';
-import { mainIndex } from './config/algoliaEnvConfig';
-import { isRulesSwitchToggle } from './config/appliedRulesConfig';
-import { isCarouselLoaded } from './config/carouselConfig';
-import { queryAtom } from './config/searchboxConfig';
+import { predictUserIdAtom } from '@/config/predictConfig'
+import { mainIndex } from '@/config/algoliaEnvConfig';
+import { isRulesSwitchToggle } from '@/config/appliedRulesConfig';
+import { isCarouselLoaded } from '@/config/carouselConfig';
+import { queryAtom } from '@/config/searchboxConfig';
 
 // Import Pages and static components
 import AlertNavigation from '@/components/demoGuide/AlertNavigation';
@@ -47,6 +48,8 @@ const ProductDetails = lazy(() =>
 );
 
 import SearchResultsPage from './pages/searchResultPage/SearchResultsPage';
+
+import PredictUserProfileProvider from './components/predict/PredictUserProfileProvider';
 
 const CartModal = lazy(() => import('./components/cart/CartModal'));
 
@@ -92,8 +95,10 @@ export const Main = () => {
 
   // Prevent body from scrolling when panel is open
   usePreventScrolling(showDemoGuide);
+  const userId = useRecoilValue(predictUserIdAtom)
 
   return (
+    <PredictUserProfileProvider userID={userId}>
     <InstantSearch searchClient={searchClient} indexName={index}>
       <InsightsMiddleware />
       {shouldShowNetworkErrors && <SearchErrorToast />}
@@ -166,6 +171,7 @@ export const Main = () => {
           </Suspense>
         )}
       </div>
-    </InstantSearch>
+      </InstantSearch>
+    // </PredictUserProfileProvider>
   );
 };

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -99,7 +99,7 @@ export const Main = () => {
 
   return (
     <PredictUserProfileProvider userID={userId}>
-    <InstantSearch searchClient={searchClient} indexName={index}>
+      <InstantSearch searchClient={searchClient} indexName={index}>
       <InsightsMiddleware />
       {shouldShowNetworkErrors && <SearchErrorToast />}
 
@@ -172,6 +172,6 @@ export const Main = () => {
         )}
       </div>
       </InstantSearch>
-    // </PredictUserProfileProvider>
+    </PredictUserProfileProvider>
   );
 };

--- a/src/components/predict/PredictUserProfileProvider.jsx
+++ b/src/components/predict/PredictUserProfileProvider.jsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import { Predict } from '@algolia/predict-react'
+import { predictUserProfileAtom } from '@/config/predictConfig'
+import { predictClient } from '@/config/algoliaEnvConfig'
+import { useRecoilState } from 'recoil'
+
+function PredictUserProfileProvider({ userID, children }) {
+  const [userProfile, setUserProfile] = useRecoilState(predictUserProfileAtom)
+
+  useEffect(() => {
+    predictClient
+      .fetchUserProfile({
+        userID,
+        params: {
+          modelsToRetrieve: ['funnel_stage', 'order_value', 'affinities'],
+          typesToRetrieve: ['properties', 'segments'],
+        },
+      })
+        .then((nextUserProfile) => {
+          setUserProfile(nextUserProfile)
+      });
+  }, [userID])
+
+  if (!userProfile) {
+    return children;
+  }
+
+  return (
+    <Predict userProfile={userProfile} suppressExperimentalWarning>
+      {children}
+    </Predict>
+  )
+}
+
+export default PredictUserProfileProvider

--- a/src/components/predict/PredictUserProfileProvider.jsx
+++ b/src/components/predict/PredictUserProfileProvider.jsx
@@ -4,6 +4,8 @@ import { predictUserProfileAtom } from '@/config/predictConfig'
 import { predictClient } from '@/config/algoliaEnvConfig'
 import { useRecoilState } from 'recoil'
 
+// PredictUserProfileProvider returns the Predict wrapper with the children encapsulated, or just the children
+// It depends on whether there is a valid user profile for the current user ID which is passed to the component
 function PredictUserProfileProvider({ userID, children }) {
   const [userProfile, setUserProfile] = useRecoilState(predictUserProfileAtom)
 

--- a/src/config/algoliaEnvConfig.js
+++ b/src/config/algoliaEnvConfig.js
@@ -56,6 +56,7 @@ export const recommendClient = algoliarecommend(
   searchClientCreds.APIKey
 );
 
+// This export is a single instanc of the Algolia Predict API client
 export const predictClient = algoliapredict(
   predictClientCreds.appID,
   predictClientCreds.APIKey,

--- a/src/config/algoliaEnvConfig.js
+++ b/src/config/algoliaEnvConfig.js
@@ -2,15 +2,10 @@
 // Config Index and Search Client
 // ------------------------------------------
 
-import algoliarecommend from '@algolia/recommend';
-import algoliasearch from 'algoliasearch';
-import { atom, selector } from 'recoil';
-
-
-
-
-
-
+import algoliarecommend from '@algolia/recommend'
+import { predictClient as algoliapredict } from '@algolia/predict'
+import algoliasearch from 'algoliasearch'
+import { atom, selector } from 'recoil'
 
 
 // ADJUST THE APIKEY AND APPID TO YOUR OWN
@@ -22,6 +17,12 @@ export const searchClientCreds = {
   // https://www.algolia.com/doc/rest-api/personalization/#get-the-current-personalization-strategy
   personaStrategyAPIKey: '4983f1e3449111609c1e7688209b787b',
 };
+
+export const predictClientCreds = {
+  APIKey: '7fee4f66e56070c0c1635e8be18381e5',
+  appID: 'YCWMGWBZQ0',
+  region: 'eu'
+}
 
 // ADJUST THE DEFAULT VALUE TO YOUR MAIN INDEX
 export const mainIndex = atom({
@@ -55,6 +56,11 @@ export const recommendClient = algoliarecommend(
   searchClientCreds.APIKey
 );
 
+export const predictClient = algoliapredict(
+  predictClientCreds.appID,
+  predictClientCreds.APIKey,
+  predictClientCreds.region
+);
 
 
 // Export an active insights client

--- a/src/config/predictConfig.js
+++ b/src/config/predictConfig.js
@@ -1,0 +1,15 @@
+// ------------------------------------------
+// Configuration for Predict accross the application
+// ------------------------------------------
+import { atom } from 'recoil';
+
+// This atom stores the current user profile for Predict
+export const predictUserProfileAtom = atom({
+    key: 'predictUserProfileAtom', // unique ID
+    default: null, // default value
+})
+
+export const predictUserIdAtom = atom({
+    key: 'predictUserIdAtom', // unique ID
+    default: "100023285.994839327", // default value
+})

--- a/src/config/predictConfig.js
+++ b/src/config/predictConfig.js
@@ -9,6 +9,7 @@ export const predictUserProfileAtom = atom({
     default: null, // default value
 })
 
+// This atom stores the current User ID related to Predict
 export const predictUserIdAtom = atom({
     key: 'predictUserIdAtom', // unique ID
     default: "100023285.994839327", // default value

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
   // },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(__dirname, './src')
     },
   },
 });


### PR DESCRIPTION
## Objective
What: Add predict to the boilerplate as a provider, to set up the following work to use predict
Why: Predict must be added to the application as a pre-requisite to us being able to use functionality
How: 
Usage:

## Type
- [X] New Feature

## Tested
Localhost

## Translation
N/A

## Documented

- [X] Have you documented in changed file using comments
- [X] Have you added instructions to the README if needed?
