### PR TITLE
refactor: pass hits through SRP instead of fetching again in hits

### DIFF
--- a/src/assets/svg/SvgIndex.jsx
+++ b/src/assets/svg/SvgIndex.jsx
@@ -2,7 +2,6 @@ import React, { memo } from 'react'
 
 export const AlgoliaLogo = memo(() => (
   <svg
-    class=""
     width="2197"
     height="501"
     viewBox="0 0 2197 501"

--- a/src/components/hits/components/CustomHits.jsx
+++ b/src/components/hits/components/CustomHits.jsx
@@ -7,39 +7,14 @@ import { useInfiniteHits } from 'react-instantsearch-hooks-web'
 import { windowSize } from '@/hooks/useScreenSize'
 import { useRecoilValue } from 'recoil'
 
-import { hitsAtom } from '@/config/hitsConfig'
-
 import CustomSkeleton from '@/components/skeletons/CustomSkeleton'
 import { Hit } from '../Hits'
 
 function CustomHits(props) {
-  // If hits were not provided via props, we will use the ones from the IS hook (see footnote)
-  const {
-    hits: hookHits,
-    isLastPage,
-    showMore,
-    sendEvent,
-  } = useInfiniteHits(props)
-
-  console.log(hookHits)
-
+  const { hits, isLastPage, showMore, sendEvent } = props
   const { mobile, tablet } = useRecoilValue(windowSize)
-  const [hits, setHits] = useState([])
-  const hitsState = useRecoilValue(hitsAtom)
-  const [hitsLoaded, setHitsLoaded] = useState(false)
+  const [hitsLoaded, setHitsLoaded] = useState(true)
   const productCard = useRef(null)
-
-  // Decide whether to use hits from hook or props
-  useEffect(() => {
-    // Check the props for the hits
-    if (props.hits != undefined) {
-      setHits(props.hits)
-      return
-    }
-
-    // Use the hook
-    else setHits(hookHits)
-  }, [props])
 
   useEffect(() => {
     if (hits.length > 0) {

--- a/src/components/hits/components/CustomHits.jsx
+++ b/src/components/hits/components/CustomHits.jsx
@@ -21,6 +21,8 @@ function CustomHits(props) {
     sendEvent,
   } = useInfiniteHits(props)
 
+  console.log(hookHits)
+
   const { mobile, tablet } = useRecoilValue(windowSize)
   const [hits, setHits] = useState([])
   const hitsState = useRecoilValue(hitsAtom)

--- a/src/components/hits/components/injected-hits/InjectedHits.jsx
+++ b/src/components/hits/components/injected-hits/InjectedHits.jsx
@@ -8,11 +8,7 @@ import { useRecoilValue } from 'recoil'
 
 import { lazy, useEffect, useState, useRef } from 'react'
 // Algolia
-import {
-  useInfiniteHits,
-  useInstantSearch,
-  useQueryRules,
-} from 'react-instantsearch-hooks-web'
+import { useInstantSearch, useQueryRules } from 'react-instantsearch-hooks-web'
 
 // Components
 import { windowSize } from '@/hooks/useScreenSize'

--- a/src/components/hits/components/injected-hits/InjectedHits.jsx
+++ b/src/components/hits/components/injected-hits/InjectedHits.jsx
@@ -12,7 +12,6 @@ import { useInstantSearch, useQueryRules } from 'react-instantsearch-hooks-web'
 
 // Components
 import { windowSize } from '@/hooks/useScreenSize'
-import { hitsAtom } from '@/config/hitsConfig'
 import CustomSkeleton from '@/components/skeletons/CustomSkeleton'
 // Components lazy loaded
 
@@ -51,7 +50,6 @@ const InjectedHits = (props) => {
   const [injectedHits, setInjectedHits] = useState(hits)
 
   const { mobile, tablet } = useRecoilValue(windowSize)
-  const hitsState = useRecoilValue(hitsAtom)
   const [hitsLoaded, setHitsLoaded] = useState(false)
   const productCard = useRef(null)
 

--- a/src/components/hits/components/injected-hits/InjectedHits.jsx
+++ b/src/components/hits/components/injected-hits/InjectedHits.jsx
@@ -37,7 +37,7 @@ const contentTypeComponentMap = {
 // This component renders the custom query hits, but also injects them with content from rule data or the injection Index
 const InjectedHits = (props) => {
   // Get the regular hits
-  const { hits, isLastPage, showMore, sendEvent } = useInfiniteHits(props)
+  const { hits, isLastPage, showMore, sendEvent } = props
 
   // Get custom data from rules
   const { items: ruleData } = useQueryRules(props)

--- a/src/config/hitsConfig.js
+++ b/src/config/hitsConfig.js
@@ -66,12 +66,6 @@ export const hitsPerPage = {
 }
 
 // Please ignore this atom
-export const hitsAtom = atom({
-  key: 'hitsAtom', // unique ID (with respect to other atoms/selectors)
-  default: [], // default value (aka initial value)
-})
-
-// Please ignore this atom
 export const hitAtom = atom({
   key: 'hitAtom', // unique ID (with respect to other atoms/selectors)
   default: {}, // default value (aka initial value)

--- a/src/pages/searchResultsPage/SearchResultsPage.jsx
+++ b/src/pages/searchResultsPage/SearchResultsPage.jsx
@@ -2,7 +2,12 @@
 import { Fragment, lazy, Suspense, useEffect, useState } from 'react'
 
 // eslint-disable-next-line import/order
-import { Configure, Index, useHits } from 'react-instantsearch-hooks-web'
+import {
+  Configure,
+  Index,
+  useHits,
+  useInfiniteHits,
+} from 'react-instantsearch-hooks-web'
 
 //import react router
 import { useSearchParams } from 'react-router-dom'
@@ -64,7 +69,7 @@ import { shouldHaveInjectedBanners } from '@/config/featuresConfig'
 import '@/pages/searchResultsPage/searchResultsPage.scss'
 
 const SearchResultsPage = () => {
-  const { hits } = useHits()
+  const { hits, isLastPage, showMore, sendEvent } = useInfiniteHits()
 
   useEffect(() => {
     if (hits.length === 0) {
@@ -256,11 +261,21 @@ const SearchResultsPage = () => {
                     <Configure hitsPerPage={1} page={0} />
                   </Index>
                   {/* Injected content*/}
-                  <InjectedHits />
+                  <InjectedHits
+                    hits={hits}
+                    isLastPage={isLastPage}
+                    showMore={showMore}
+                    sendEvent={sendEvent}
+                  />
                 </Suspense>
               ) : (
                 <Suspense fallback={<SkeletonLoader type={'hit'} />}>
-                  <CustomHits />
+                  <CustomHits
+                    hits={hits}
+                    isLastPage={isLastPage}
+                    showMore={showMore}
+                    sendEvent={sendEvent}
+                  />
                 </Suspense>
               )}
             </div>


### PR DESCRIPTION
## Objective

What: Fetch hits in SRP component and pass to hits instead of fetching hits twice, once in SRP and then in hits
Why: There was no need to fetch hits multiple times, we control the state better if we do it once in the parent
How: useInfinite hits in SRP and removes from injectedHits and from customHits
Usage: as normal

## Type

- [X] Bug Fix
- [X] Code Refactoring

## Tested
Localhost, please test all the nav links, and the dropdowns in combination with empty search and a search term

## Translation
N/A

## Documented
N/A
