### PR TITLE
Feat/ranking info comparison

### DIFF
--- a/apps/boilerplate-front-end/src/components/demoGuide/components/DemoGuideLandingPage.jsx
+++ b/apps/boilerplate-front-end/src/components/demoGuide/components/DemoGuideLandingPage.jsx
@@ -11,7 +11,7 @@ const DemoGuideLandingPage = ({ triggerAlert, refine }) => {
 
   const handleLandingPage = (landingPage) => {
     // Create route to trigger the context and get the right landing page
-    navigate(`/search?contextMarketingCampaign=${landingPage.value}`)
+    navigate(`/search?context=${landingPage.value}`)
     // Refresh the page to trigger the context (faking coming from another page)
     // window.location.reload()
   }

--- a/apps/boilerplate-front-end/src/components/hits/Hit.jsx
+++ b/apps/boilerplate-front-end/src/components/hits/Hit.jsx
@@ -30,6 +30,8 @@ import useStoreIdToLocalStorage from '@/hooks/useStoreObjectIdToLocalStorage'
 // import Price component
 import Price from '@/components/hits/components/Price.jsx'
 
+import RankingFormulaOverlay from './components/Ranking'
+
 // Import cart from recoil(Cart state and the event if it's removed)
 import { addToCartSelector, cartClick, cartState } from '@/config/cartFunctions'
 // Import Persona if there is
@@ -45,7 +47,7 @@ import {
 //Import scope SCSS
 import './SCSS/hits.scss'
 
-const Hit = ({ hit, sendEvent }) => {
+const Hit = ({ hit, nextHit, sendEvent }) => {
   const navigate = useNavigate()
   const hitState = useSetRecoilState(hitAtom)
   const [isHovered, setIsHovered] = useState(false)
@@ -69,30 +71,6 @@ const Hit = ({ hit, sendEvent }) => {
   const { objectID, image, imageAlt, category, productName, brand } = hitsConfig
 
   const [shouldShowRankingInfo, setShouldShowRankingInfo] = useState(false)
-
-  const RankingFormulaOverlay = ({ hit }) => {
-    return (
-      <motion.div
-        variants={framerMotionHits}
-        initial={framerMotionHits.initial}
-        exit={framerMotionHits.exit}
-        animate={framerMotionHits.animate}
-        transition={{
-          duration: 0.3,
-          delay: 0,
-          ease: [0.43, 0.13, 0.23, 0.96],
-        }}
-        className="ranking-formula"
-      >
-        {hit._rankingInfo &&
-          Object.entries(hit._rankingInfo).map((entry, i) => (
-            <p key={i}>
-              {entry[0]} {JSON.stringify(entry[1])}
-            </p>
-          ))}
-      </motion.div>
-    )
-  }
 
   const promoted = hit?._rankingInfo?.promoted
   // Update the qty for a product on SRP each time Cart is modified or set qty to 0
@@ -130,7 +108,9 @@ const Hit = ({ hit, sendEvent }) => {
         <p>Click to see Ranking</p>
       </div>
       <AnimatePresence>
-        {shouldShowRankingInfo && <RankingFormulaOverlay hit={hit} />}
+        {shouldShowRankingInfo && (
+          <RankingFormulaOverlay hit={hit} nextHit={nextHit} />
+        )}
       </AnimatePresence>
       <>
         <div
@@ -207,46 +187,3 @@ const Hit = ({ hit, sendEvent }) => {
 }
 
 export { Hit }
-
-// KEEP IT FOR NOW
-{
-  /* {shouldShowCartIcons && (
-<div className="srpItem__infosDown__cart">
-  <div
-    className={`${
-      itemQty === 0 && 'srpItem__infosDown__minusPicto-inactive '
-    }${cartPictoMinusClicked && 'picto-active'}`}
-    onClick={() => {
-      setCartPictoMinusClicked(true)
-      setTimeout(() => setCartPictoMinusClicked(false), 300)
-      setRemoveToCartAtom(hit)
-    }}
-  >
-    <MinusPicto />
-  </div>
-  <p
-    className={
-      itemQty === 0 ? 'srpItem__infosDown__cart-inactive' : ''
-    }
-  >
-    {itemQty}
-  </p>
-  <div
-    className={
-      cartPictoPlusClicked
-        ? 'picto-active srpItem__infosDown__cart-plus'
-        : 'srpItem__infosDown__cart-plus'
-    }
-    onClick={() => {
-      setCartPictoPlusClicked(true)
-      setTimeout(() => setCartPictoPlusClicked(false), 300)
-      setAddToCartAtom(hit)
-      // Send event conversion to Algolia API
-      sendEvent('conversion', hit, 'SRP: Add to cart')
-    }}
-  >
-    <PlusPicto />
-  </div>
-</div>
-)} */
-}

--- a/apps/boilerplate-front-end/src/components/hits/components/CustomHits.jsx
+++ b/apps/boilerplate-front-end/src/components/hits/components/CustomHits.jsx
@@ -7,7 +7,7 @@ import { windowSize } from '@/hooks/useScreenSize'
 import { useRecoilValue } from 'recoil'
 
 import CustomSkeleton from '@/components/skeletons/CustomSkeleton'
-import { Hit } from '../Hits'
+import { Hit } from '../Hit'
 
 function CustomHits(props) {
   const { hits, isLastPage, showMore, sendEvent } = props
@@ -57,7 +57,7 @@ function CustomHits(props) {
             return (
               <li key={hit.objectID}>
                 {hitsLoaded ? (
-                  <hit._component hit={hit} />
+                  <hit._component hit={hit} nextHit={hits[index + 1]} />
                 ) : (
                   <CustomSkeleton type="hit" />
                 )}
@@ -67,7 +67,11 @@ function CustomHits(props) {
           return (
             <li key={hit.objectID}>
               {hitsLoaded ? (
-                <Hit hit={hit} sendEvent={sendEvent} />
+                <Hit
+                  hit={hit}
+                  nextHit={hits[index + 1]}
+                  sendEvent={sendEvent}
+                />
               ) : (
                 <CustomSkeleton type="hit" />
               )}

--- a/apps/boilerplate-front-end/src/components/hits/components/Ranking.jsx
+++ b/apps/boilerplate-front-end/src/components/hits/components/Ranking.jsx
@@ -1,0 +1,47 @@
+// Import framer-motion for animation on hits
+import { motion } from 'framer-motion'
+
+import * as _ from 'lodash'
+
+import { framerMotionHits } from '@/config/animationConfig'
+
+const RankingFormulaOverlay = ({ hit, nextHit }) => {
+  if (nextHit === undefined) return <p>Scroll to load more results</p>
+
+  const changes = _.differenceWith(
+    _.toPairs(nextHit._rankingInfo),
+    _.toPairs(hit._rankingInfo),
+    _.isEqual
+  )
+
+  return (
+    <motion.div
+      variants={framerMotionHits}
+      initial={framerMotionHits.initial}
+      exit={framerMotionHits.exit}
+      animate={framerMotionHits.animate}
+      transition={{
+        duration: 0.3,
+        delay: 0,
+        ease: [0.43, 0.13, 0.23, 0.96],
+      }}
+      className="ranking-formula"
+    >
+      {hit._rankingInfo &&
+        changes.length &&
+        changes.map((change) => {
+          return (
+            <p>
+              {change[0]} of {JSON.stringify(hit._rankingInfo[change[0]])} vs{' '}
+              {JSON.stringify(nextHit._rankingInfo[change[0]])}
+            </p>
+          )
+        })}
+      {hit._rankingInfo && change.length === 0 && (
+        <p>result is the same as the next result</p>
+      )}
+    </motion.div>
+  )
+}
+
+export default RankingFormulaOverlay

--- a/apps/boilerplate-front-end/src/components/hits/components/injected-hits/InjectedHits.jsx
+++ b/apps/boilerplate-front-end/src/components/hits/components/injected-hits/InjectedHits.jsx
@@ -1,6 +1,6 @@
 // Import the custom hits to display in the SRP
 // import CustomHits from '../CustomHits';
-import { Hit } from '../../Hits'
+import { Hit } from '../../Hit'
 // Import the config files we'll need to import
 import { indexNames } from '@/config/algoliaEnvConfig'
 import { useRecoilValue } from 'recoil'
@@ -150,14 +150,14 @@ const InjectedHits = (props) => {
             : ''
         }`}
       >
-        {injectedHits.map((hit) => {
+        {injectedHits.map((hit, index) => {
           // Wrap the hit info in an animation, and click functionality to view the product
           if (hit._component != undefined) {
             // If the hit has a component property, use it instead of the default component
             return (
               <li key={hit.objectID}>
                 {hitsLoaded ? (
-                  <hit._component hit={hit} />
+                  <hit._component hit={hit} nextHit={hits[index + 1]} />
                 ) : (
                   <CustomSkeleton type="hit" />
                 )}
@@ -167,7 +167,11 @@ const InjectedHits = (props) => {
           return (
             <li key={hit.objectID}>
               {hitsLoaded ? (
-                <Hit hit={hit} sendEvent={sendEvent} />
+                <Hit
+                  hit={hit}
+                  nextHit={hits[index + 1]}
+                  sendEvent={sendEvent}
+                />
               ) : (
                 <CustomSkeleton type="hit" />
               )}

--- a/apps/boilerplate-front-end/src/components/re-ranking/DRR.jsx
+++ b/apps/boilerplate-front-end/src/components/re-ranking/DRR.jsx
@@ -1,0 +1,22 @@
+import Switch from '@mui/material/Switch'
+import { activateDRR } from '@/config/rerankingConfig'
+import { useRecoilState } from 'recoil'
+import './reranking.scss'
+
+function ReRankingToggle() {
+  const [isDRRActivated, setIsDRRActivated] = useRecoilState(activateDRR)
+  return (
+    <div className="drr-toggle-container">
+      <p className="drr-text">
+        {isDRRActivated ? 'De-activate' : 'Activate'} AI re-ranking
+      </p>
+      <Switch
+        className="drr-switch"
+        checked={isDRRActivated}
+        onChange={() => setIsDRRActivated(!isDRRActivated)}
+      />
+    </div>
+  )
+}
+
+export default ReRankingToggle

--- a/apps/boilerplate-front-end/src/components/re-ranking/reranking.scss
+++ b/apps/boilerplate-front-end/src/components/re-ranking/reranking.scss
@@ -1,0 +1,20 @@
+.drr-toggle-container {
+  display: flex;
+  justify-content: space-evenly;
+}
+
+.drr-switch {
+  margin-top: -0.5rem;
+}
+
+@media (max-width: 768px) {
+  .drr-toggle-container {
+    justify-content: center;
+    align-items: flex-start;
+    order: 1;
+  }
+}
+
+.drr-text {
+  font-size: 0.8rem;
+}

--- a/apps/boilerplate-front-end/src/components/sortBy/SortBy.jsx
+++ b/apps/boilerplate-front-end/src/components/sortBy/SortBy.jsx
@@ -1,11 +1,13 @@
 // This is for displaying the SortBy widget, eg Price asc/desc
 import { useSortBy } from 'react-instantsearch-hooks-web'
+import './sortby.scss'
 
 function CustomSortBy(props) {
   const { refine } = useSortBy(props)
   const { items } = props
   return (
-    <div>
+    <div className="sort-container">
+      <p className="sort-text">Sort By: </p>
       <select
         onChange={(event) => {
           event.preventDefault()

--- a/apps/boilerplate-front-end/src/components/sortBy/sortby.scss
+++ b/apps/boilerplate-front-end/src/components/sortBy/sortby.scss
@@ -1,0 +1,21 @@
+.sort-container {
+  display: flex;
+  align-items: center;
+}
+
+@media (max-width: 768px) {
+  .sort-container {
+    margin: 1rem 0;
+    justify-content: center;
+    order: 3;
+  }
+
+  .sort-text {
+    display: none;
+  }
+}
+
+.sort-text {
+  font-size: 0.9rem;
+  margin-right: 0.5rem;
+}

--- a/apps/boilerplate-front-end/src/config/badgeConfig.js
+++ b/apps/boilerplate-front-end/src/config/badgeConfig.js
@@ -11,7 +11,15 @@ const criteriaConditionals = [
       // if the item is promoted by a rule
       attribute: '_rankingInfo.promoted',
       condition: true,
-      badgeTitle: 'Popular',
+      badgeTitle: 'Pinned',
+    },
+  },
+  {
+    conditional: {
+      // if the item is promoted by a rule
+      attribute: '_rankingInfo.promotedByReRanking',
+      condition: true,
+      badgeTitle: 'AI Re-Ranked',
     },
   },
   {

--- a/apps/boilerplate-front-end/src/config/featuresConfig.js
+++ b/apps/boilerplate-front-end/src/config/featuresConfig.js
@@ -54,6 +54,11 @@ export const shouldHaveStats = atom({
   default: true,
 })
 
+export const shouldHaveReRankingSwitch = atom({
+  key: 'shouldHaveReRankingSwitch',
+  default: true,
+})
+
 // Make sure you create a rule in the dahsboard before turn it on
 export const shouldHaveInjectedBanners = atom({
   key: 'shouldHaveInjectedBanners',

--- a/apps/boilerplate-front-end/src/config/rerankingConfig.js
+++ b/apps/boilerplate-front-end/src/config/rerankingConfig.js
@@ -1,0 +1,6 @@
+import { atom } from 'recoil'
+
+export const activateDRR = atom({
+  key: 'activateDRR', // unique ID (with respect to other atoms/selectors)
+  default: false, // default value (aka initial value)
+})

--- a/apps/boilerplate-front-end/src/pages/searchResultsPage/SearchResultsPage.jsx
+++ b/apps/boilerplate-front-end/src/pages/searchResultsPage/SearchResultsPage.jsx
@@ -37,6 +37,7 @@ const GenericRefinementList = lazy(() => import('@/components/facets/Facets'))
 
 // Configuration
 import { indexNames, mainIndex } from '@/config/algoliaEnvConfig'
+import { activateDRR } from '@/config/rerankingConfig'
 import {
   shouldHaveInjectedHits,
   shouldHaveSorts,
@@ -73,8 +74,10 @@ import {
   isHierarchicalFilterAttribute,
   navigationStateAtom,
 } from '@/config/navigationConfig'
+import ReRankingToggle from '@/components/re-ranking/DRR'
 
 const SearchResultsPage = ({ query }) => {
+  const [isDRRActivated, setIsDRRActivated] = useRecoilState(activateDRR)
   let [categoryPageId, setCategoryPageId] = useState('')
   const { indexUiState } = useInstantSearch()
 
@@ -210,6 +213,7 @@ const SearchResultsPage = ({ query }) => {
     optionalFilters: segment.value,
     ruleContexts: buildRuleContexts(),
     getRankingInfo: true,
+    enableReRanking: isDRRActivated,
   }
 
   return (
@@ -319,6 +323,7 @@ const SearchResultsPage = ({ query }) => {
                   <CustomSortBy items={labelIndex} defaultRefinement={index} />
                 </Suspense>
               )}
+              <ReRankingToggle />
             </div>
             {/* Refinements, to the left of the items, including a list of currently selected refinements */}
             <div className="refinement-container">

--- a/apps/boilerplate-front-end/src/pages/searchResultsPage/SearchResultsPage.jsx
+++ b/apps/boilerplate-front-end/src/pages/searchResultsPage/SearchResultsPage.jsx
@@ -40,6 +40,7 @@ import { indexNames, mainIndex } from '@/config/algoliaEnvConfig'
 import { activateDRR } from '@/config/rerankingConfig'
 import {
   shouldHaveInjectedHits,
+  shouldHaveReRankingSwitch,
   shouldHaveSorts,
   shouldHaveStats,
   shouldHaveTrendingFacets,
@@ -108,6 +109,10 @@ const SearchResultsPage = ({ query }) => {
 
   // Define Price Sort By Const
   const { labelIndex } = useRecoilValue(sortBy)
+
+  const shouldHaveReRankingSwitchAtom = useRecoilValue(
+    shouldHaveReRankingSwitch
+  )
 
   const shouldHaveSortsAtom = useRecoilValue(shouldHaveSorts)
 
@@ -323,7 +328,7 @@ const SearchResultsPage = ({ query }) => {
                   <CustomSortBy items={labelIndex} defaultRefinement={index} />
                 </Suspense>
               )}
-              <ReRankingToggle />
+              {shouldHaveReRankingSwitchAtom && <ReRankingToggle />}
             </div>
             {/* Refinements, to the left of the items, including a list of currently selected refinements */}
             <div className="refinement-container">

--- a/apps/boilerplate-front-end/src/pages/searchResultsPage/searchResultsPage.scss
+++ b/apps/boilerplate-front-end/src/pages/searchResultsPage/searchResultsPage.scss
@@ -68,6 +68,7 @@
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
+  align-items: center;
 
   .stats-infos {
     @include stats($secondary-color);

--- a/apps/boilerplate-front-end/src/pages/searchResultsPage/searchResultsPage.scss
+++ b/apps/boilerplate-front-end/src/pages/searchResultsPage/searchResultsPage.scss
@@ -33,20 +33,19 @@
     padding: 0 1rem;
   }
 
-  &__searchInfos{
+  &__searchInfos {
     display: flex;
     justify-content: flex-start;
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 1rem;
 
-    p{
+    p {
       @include p-text($main-color, 600);
       font-size: 1.4rem;
-        &:last-child{
-         color: $secondary-color; 
-         text-transform: capitalize
-
+      &:last-child {
+        color: $secondary-color;
+        text-transform: capitalize;
       }
     }
   }
@@ -68,9 +67,18 @@
 .srp-container__stats-sort {
   display: flex;
   justify-content: space-between;
+  flex-wrap: wrap;
 
   .stats-infos {
     @include stats($secondary-color);
+  }
+
+  @media (max-width: 768px) {
+    .stats-infos {
+      // flex: 100%;
+      margin: 1rem 0;
+      order: 2;
+    }
   }
 
   select {
@@ -263,11 +271,12 @@
   }
 }
 
-
 @keyframes loading {
-  0%{opacity: 0;}
+  0% {
+    opacity: 0;
+  }
 
-  100%{
+  100% {
     opacity: 1;
   }
 }

--- a/apps/boilerplate-front-end/src/scss/partials/_mixin.scss
+++ b/apps/boilerplate-front-end/src/scss/partials/_mixin.scss
@@ -200,6 +200,8 @@
 // ------------------------------------------
 @mixin stats($span-color) {
   display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 0.8rem;
   font-style: italic;
   &__list {


### PR DESCRIPTION
What: only show the difference between the next hit in the ranking info overlay
Why: full ranking formula is overwhelming and unhelpful
How: compare to next hit, show message if next hit not loaded