### PR TITLE
feat: hide or show algolia explain toggle via atom in demo guide

### DIFF
--- a/apps/boilerplate-front-end/src/components/demoGuide/DemoGuide.jsx
+++ b/apps/boilerplate-front-end/src/components/demoGuide/DemoGuide.jsx
@@ -22,7 +22,6 @@ import { motion } from 'framer-motion'
 // Import Reference for the Button that trigger the panel
 import {
   demoGuideBtnRef,
-  shouldShowAppliedRulesSwitcher,
   shouldShowBanners,
   shouldShowDynamicFilters,
   shouldShowInjectedContent,
@@ -30,6 +29,7 @@ import {
   shouldShowRedirects,
   shouldShowSearchTerms,
   shouldShowLandingPages,
+  shouldHaveAlgoliaExplain,
 } from '@/config/demoGuideConfig'
 
 import { alertContent, isAlertOpen } from '@/config/demoGuideConfig'
@@ -50,6 +50,7 @@ const DemoGuide = ({ refine, setshowDemoGuide }) => {
   // //Select Panel wrapper
   const demoGuide = useRef()
 
+  const shouldHaveAlgoliaExplainAtom = useRecoilValue(shouldHaveAlgoliaExplain)
   const shouldShowLandingPagesAtom = useRecoilValue(shouldShowLandingPages)
   const shouldShowPersonasAtom = useRecoilValue(shouldShowPersonas)
   const shouldShowSearchTermsAtom = useRecoilValue(shouldShowSearchTerms)
@@ -59,10 +60,6 @@ const DemoGuide = ({ refine, setshowDemoGuide }) => {
   const shouldShowDynamicFiltersAtom = useRecoilValue(shouldShowDynamicFilters)
   const shouldShowRedirectsAtom = useRecoilValue(shouldShowRedirects)
   const shouldShowBannersAtom = useRecoilValue(shouldShowBanners)
-  // Should the applied rules section shows in the demo panel
-  const shouldShowRulesAppliedAtom = useRecoilValue(
-    shouldShowAppliedRulesSwitcher
-  )
 
   // Use the reference value of the button that trigger the panel
   const demoGuideBtn = useRecoilValue(demoGuideBtnRef)
@@ -88,7 +85,7 @@ const DemoGuide = ({ refine, setshowDemoGuide }) => {
     >
       <h2>Help Navigation Panel</h2>
       <ul className="container-nav-help">
-        {shouldShowRulesAppliedAtom && (
+        {shouldHaveAlgoliaExplain && (
           <li className="container-nav-help__items ">
             <DemoGuideAlgoliaExplain />
             <hr />

--- a/apps/boilerplate-front-end/src/config/demoGuideConfig.js
+++ b/apps/boilerplate-front-end/src/config/demoGuideConfig.js
@@ -3,6 +3,11 @@ import { atom } from 'recoil'
 // import personaConfig for displaying in the guide
 import { personaConfig } from './personaConfig'
 
+export const shouldHaveAlgoliaExplain = atom({
+  key: 'shouldHaveAlgoliaExplain',
+  default: true,
+})
+
 // Should we show the network errors in the demo - might want to switch this to false when demo-ing to a client
 export const showNetworkErorrs = atom({
   key: 'showNetworkErorrs',
@@ -92,23 +97,6 @@ export const searchTermsConfig = [
     alertContent: 'The categories winter jacket and hike shoes are boosted.',
     details: 'The categories winter jacket and hike shoes will be boosted.',
     type: 'search terms',
-  },
-]
-
-// ------------------------------------------
-// Applied Rules
-// Will show the rules applied in the app while browsing
-// ------------------------------------------
-// Should we show the applied rules Switcher
-export const shouldShowAppliedRulesSwitcher = atom({
-  key: 'shouldShowAppliedRulesSwitcher',
-  default: true,
-})
-// What should be the information showed to the user
-export const appliedRulesInformations = [
-  {
-    span: 'Rules On',
-    details: 'The rules that are apply will be shown live',
   },
 ]
 


### PR DESCRIPTION
What: Ability to show or hide the algolia explain toggle
Why: Sometimes the demo will not include such a feature
How: Atom & conditional render