### PR TITLE
fix: add index because of using it without defined it

### DIFF
--- a/apps/boilerplate-front-end/src/components/hits/components/CustomHits.jsx
+++ b/apps/boilerplate-front-end/src/components/hits/components/CustomHits.jsx
@@ -50,7 +50,7 @@ function CustomHits(props) {
             : ''
         }`}
       >
-        {hits.map((hit) => {
+        {hits.map((hit, index) => {
           // Wrap the hit info in an animation, and click functionality to view the product
           if (hit._component != undefined) {
             // If the hit has a component property, use it instead of the default component


### PR DESCRIPTION
Add index in a map because of an issue on iteration on it but it didn't exists.